### PR TITLE
add optional user-specified datetime support

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -26,9 +26,9 @@ namespace Raygun4php
     * data in the message payload
     * @return The HTTP status code of the result when transmitting the message to Raygun.io
     */
-    public function SendError($errno, $errstr, $errfile, $errline, $tags = null, $userCustomData = null)
+    public function SendError($errno, $errstr, $errfile, $errline, $tags = null, $userCustomData = null, $timestamp = null)
     {
-      $message = $this->BuildMessage(new \ErrorException($errstr, $errno, 0, $errfile, $errline));
+      $message = $this->BuildMessage(new \ErrorException($errstr, $errno, 0, $errfile, $errline), $timestamp);
 
       if ($tags != null)
       {
@@ -49,9 +49,9 @@ namespace Raygun4php
     * data in the message payload
     * @return The HTTP status code of the result when transmitting the message to Raygun.io
     */
-    public function SendException($exception, $tags = null, $userCustomData = null)
+    public function SendException($exception, $tags = null, $userCustomData = null, $timestamp = null)
     {
-      $message = $this->BuildMessage($exception);
+      $message = $this->BuildMessage($exception, $timestamp);
 
       if ($tags != null)
       {
@@ -84,9 +84,9 @@ namespace Raygun4php
      * are sent.
      * @param array $tags The tags relating to your project's version
     */
-    private function BuildMessage($errorException)
+    private function BuildMessage($errorException, $timestamp = null)
     {
-        $message = new RaygunMessage();
+        $message = new RaygunMessage($timestamp);
         $message->Build($errorException);
         $message->Details->Version = $this->version;
         return $message;

--- a/src/Raygun4php/RaygunMessage.php
+++ b/src/Raygun4php/RaygunMessage.php
@@ -12,9 +12,12 @@ namespace Raygun4php
         public $OccurredOn;
         public $Details;
 
-        public function __construct()
+        public function __construct($timestamp = null)
         {
-            $this->OccurredOn = gmdate("Y-m-d\TH:i:s");
+            if ($timestamp === null) {
+                $timestamp = time();
+            }
+            $this->OccurredOn = gmdate("Y-m-d\TH:i:s", $timestamp);
             $this->Details = new RaygunMessageDetails();
         }
 


### PR DESCRIPTION
Useful for delayed log sending, for example if i write errors in php_errors.log and then send them to raygun with cron. 
