### PR TITLE
Strip invalid UTF8 $_SERVER values

### DIFF
--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -30,7 +30,14 @@ namespace Raygun4php
             }
 
             $this->headers = $this->emu_getAllHeaders();
-            $this->data = $_SERVER;
+
+            $mb_utf8_convert = function($value) use (&$mb_utf8_convert) {
+                return is_array($value) ?
+                array_map($mb_utf8_convert, $value) :
+                mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+            };
+            $this->data = array_map($mb_utf8_convert, $_SERVER);            
+
 
             $utf8_convert = function($value) use (&$utf8_convert) {
                 return is_array($value) ?


### PR DESCRIPTION
This introduces a mbstring library requirement. So it may not be a good merge candidate but wanted to detail the issue. (utf8_decode may also handle it and am not sure if it introduces the mbstring requirement)

A little more in-depth on what is going on in my use case.

We use MaxMind's geoip to add server variables for country/city/etc. Sao Paulo has an accent over the a (ala São Paulo). Not sure if MaxMind is the issue or what but thousands of errors are showing up in Raygun due to our uptime monitor being located in São Paulo and everytime it tries to json_encode it throws up with "invalid UTF-8 sequence".

This is what MaxMind GeoIP shows: S\xe3o Paulo.

Let's discuss how we can handle this so these false positive errors go away and I can clean up my Raygun dash. Another alternative may be to allow me to ignore those variables the same way that you could white/blacklist per my other feature request #32.

Thanks!
