### PR TITLE
Switched to preg_replace_callback for PHP 5.5

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -292,7 +292,7 @@ namespace Raygun4php {
     }
 
     function toJsonRemoveUnicodeSequences($struct) {
-      return preg_replace("/\\\\u([a-f0-9]{4})/e", "iconv('UCS-4LE','UTF-8',pack('V', hexdec('U$1')))", json_encode($struct));
+      return preg_replace_callback("/\\\\u([a-f0-9]{4})/", function($matches){ return iconv('UCS-4LE','UTF-8',pack('V', hexdec("U$matches[1]"))); }, json_encode($struct)) );
     }
 
     public function __destruct()


### PR DESCRIPTION
Adapting toJsonRemoveUnicodeSequences function to use preg_replace_callback instead of preg_replace because the e modifier is [deprecated](http://php.net/manual/en/reference.pcre.pattern.modifiers.php) as of PHP 5.5.0
