### PR TITLE
add support for x-forwarded-for header

### DIFF
--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -103,11 +103,16 @@ namespace Raygun4php
 	     */
 	    private function getRemoteAddr()
 	    {
-    		$ip = &$_SERVER['HTTP_X_FORWARDED_FOR'];
-    		if (empty($ip)) {
-    		    $ip = &$_SERVER['REMOTE_ADDR'];
-    		}
-    		return $ip;
+		    $ip = null;
+
+		    if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+			    $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+		    }
+		    else if (!empty($_SERVER['REMOTE_ADDR'])) {
+			    $ip = $_SERVER['REMOTE_ADDR'];
+		    }
+
+		    return $ip;
 	    }
     }
 }


### PR DESCRIPTION
add function to use x-forwarded-for or remote-addr if x-forwarded-for is not set to get the remote client ip. this is useful for sites/apps that are behind a load balancer.
