### PR TITLE
Prevent conflicts with duplicate library

### DIFF
--- a/src/Raygun4php/Exception/UnsatisfiedDependencyException.php
+++ b/src/Raygun4php/Exception/UnsatisfiedDependencyException.php
@@ -9,7 +9,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace Rhumsaa\Uuid\Exception;
+namespace Raygun4Php\Rhumsaa\Uuid\Exception;
 
 /**
  * Thrown to indicate that the requested operation has depencies that have not

--- a/src/Raygun4php/Exception/UnsupportedOperationException.php
+++ b/src/Raygun4php/Exception/UnsupportedOperationException.php
@@ -9,7 +9,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace Rhumsaa\Uuid\Exception;
+namespace Raygun4Php\Rhumsaa\Uuid\Exception;
 
 /**
  * Thrown to indicate that the requested operation is not supported.

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -5,7 +5,7 @@ namespace Raygun4php {
   require_once realpath(__DIR__ . '/Raygun4PhpException.php');
   require_once realpath(__DIR__ . '/Uuid.php');
 
-  use Rhumsaa\Uuid\Uuid;
+  use Raygun4Php\Rhumsaa\Uuid\Uuid;
 
   class RaygunClient
   {

--- a/src/Raygun4php/Uuid.php
+++ b/src/Raygun4php/Uuid.php
@@ -9,7 +9,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace Rhumsaa\Uuid;
+namespace Raygun4Php\Rhumsaa\Uuid;
 
 use InvalidArgumentException;
 


### PR DESCRIPTION
Create Raygun4Php\Rhumsaa namespace and descendents to avoid conflicts with separately loaded Rhumsaa\Uuid library
