### PR TITLE
Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: php
+
+php: [5.3, 5.4, 5.5]
+
+before_script:
+  - composer self-update
+  - composer install --dev --prefer-source --no-interaction --no-progress
+
+script: 'vendor/bin/phpunit tests'

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ Raygun4php
 
 [Raygun.io](http://raygun.io) provider for PHP 5.3+
 
+[![Build
+Status](https://secure.travis-ci.org/MindscapeHQ/raygun4php.png?branch=master)](http://travis-ci.org/MindscapeHQ/raygun4php)
+
 ## Installation
 
 Firstly, ensure that **curl** is installed and enabled in your server's php.ini file.

--- a/testbootstrap.php
+++ b/testbootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-require_once(__DIR__ .'\src\Raygun4php\RaygunClient.php');
+require_once(__DIR__ .'/src/Raygun4php/RaygunClient.php');


### PR DESCRIPTION
Already in place for the Ruby client, makes sense for PHP as well :) You'll need to activate the project in Travis after merging this, by logging into Travis via Github on an account that has admin privileges on this repo.

Fixed up the `require_once` call in the PHPUnit bootstrap to use forward slashes for directory separation, since its compatible with both Unix and Windows. That seems to be in place for other `require` calls across the codebase already, and might've been missed in this case.

Verified the build passes on my fork: https://travis-ci.org/chillu/raygun4php/builds/28091609
