### PR TITLE
Correctly detect an ErrorException created from a manual SendError call

### DIFF
--- a/src/Raygun4php/RaygunClientMessage.php
+++ b/src/Raygun4php/RaygunClientMessage.php
@@ -10,7 +10,7 @@ namespace Raygun4php
         public function __construct()
         {
             $this->name = "Raygun4php";
-            $this->version = "1.4.0";
+            $this->version = "1.4.1";
             $this->clientUrl = "https://github.com/MindscapeHQ/raygun4php";
         }
     }

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -41,13 +41,12 @@ namespace Raygun4php
             if (array_key_exists('function', $trace) &&
                 array_key_exists('class', $trace))
             {
-
               if ($trace['function'] == 'SendError' && $trace['class'] == 'Raygun4php\RaygunClient')
               {
                 $fromManualSendError = true;
               }
-
             }
+
             if (array_key_exists('args', $trace) && $fromManualSendError == true) {
               $errorData = $trace['args'];
 


### PR DESCRIPTION
This fixes null backtrace frames in regular trigger_errors caught by the error handler
