### PR TITLE
Fix: Bootstrap tests by requiring vendor/autoload.php

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="testbootstrap.php"
+         bootstrap="vendor/autoload.php"
          colors="true"
          syntaxCheck="false">
   <testsuites>

--- a/testbootstrap.php
+++ b/testbootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once(__DIR__ .'/src/Raygun4php/RaygunClient.php');


### PR DESCRIPTION
This PR

* [x] uses `vendor/autoload.php` as a test bootstrapper, as autoloading is all that is required
* [x] removes the useless `testbootstrap.php` file