### PR TITLE
Enhancement: Speed up builds on Travis, improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ php:
   - 7.0
 
 install:
-  - composer install --prefer-source --no-interaction --no-progress
+  - composer install --no-interaction --no-progress
 
 script: 'vendor/bin/phpunit tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - 5.5
   - 7.0
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - 5.5
   - 7.0
 
-before_script:
+install:
   - composer install --prefer-source --no-interaction --no-progress
 
 script: 'vendor/bin/phpunit tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
 
-php: [5.4, 5.5, 7.0]
+php:
+  - 5.4
+  - 5.5
+  - 7.0
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ php:
   - 7.0
 
 install:
-  - composer install --no-interaction --no-progress
+  - composer install
 
 script: 'vendor/bin/phpunit tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.0
 
 before_script:
-  - composer self-update
   - composer install --prefer-source --no-interaction --no-progress
 
 script: 'vendor/bin/phpunit tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ php:
 install:
   - composer install
 
-script: 'vendor/bin/phpunit tests'
+script:
+  - vendor/bin/phpunit tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit tests
+  - vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,8 @@
         "psr-0": {
             "Raygun4php": "src/"
         }
+    },
+    "config": {
+        "preferred-install": "dist"
     }
 }


### PR DESCRIPTION
This PR fixes a few issues with `.travis.yml` and also squeezes in a few improvements:
- [x] puts each PHP version on a a line of its own
- [x] installs dependencies in `install` section (semantically better than `before_script`)
- [x] removes argument from test command, will pickup configuration in `phpunit.xml` anyways 
- [x] leverages container-based infrastructure on Travis by disabling `sudo`, should speed up builds (see http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure)
- [x] leverages caching of dependencies on Travis, should speed up builds as well (see http://docs.travis-ci.com/user/caching/#Configuration)
