### PR TITLE
[WIP] Fix: Do not suggest to clone repo to use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,6 @@ require_once 'vendor/autoload.php';
 ```
 and the library will be imported ready for use.
 
-### Manually with Git
-
-Clone this repository and copy src/Raygun4php into an appropriate subdirectory in your project, such as /vendor/Raygun4php. Add `requires` definitions for RaygunClient.php where you want to make a call to Send().
-
-```php
-require (dirname(dirname(__FILE__)).'/vendor/Raygun4php/RaygunClient.php');
-```
 ## Usage
 
 You can send both PHP errors and object-oriented exceptions to Raygun. An easy way to accomplish this is to create a file containing exception and error handlers which make calls to the appropriate Raygun4PHP functions. As above, import Raygun4PHP - if you're using Composer, just add `require_once 'vendor/autoload.php'`, or if not manually import RaygunClient.php.

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -1,9 +1,5 @@
 <?php
 namespace Raygun4php {
-  require_once realpath(__DIR__ . '/RaygunMessage.php');
-  require_once realpath(__DIR__ . '/RaygunIdentifier.php');
-  require_once realpath(__DIR__ . '/Raygun4PhpException.php');
-  require_once realpath(__DIR__ . '/Uuid.php');
 
   use Raygun4Php\Rhumsaa\Uuid\Uuid;
 

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -1,8 +1,6 @@
 <?php
 namespace Raygun4php
 {
-    require_once realpath(__DIR__.'/RaygunExceptionTraceLineMessage.php');
-
     class RaygunExceptionMessage
     {
         public $Message;

--- a/src/Raygun4php/RaygunMessage.php
+++ b/src/Raygun4php/RaygunMessage.php
@@ -1,12 +1,6 @@
 <?php
 namespace Raygun4php
 {
-    require_once realpath(__DIR__.'/RaygunMessageDetails.php');
-    require_once realpath(__DIR__.'/RaygunExceptionMessage.php');
-    require_once realpath(__DIR__.'/RaygunRequestMessage.php');
-    require_once realpath(__DIR__.'/RaygunEnvironmentMessage.php');
-    require_once realpath(__DIR__.'/RaygunClientMessage.php');
-
     class RaygunMessage
     {
         public $OccurredOn;


### PR DESCRIPTION
This PR

* [x] removes the suggestion to clone the repository when you want to use it (if you're not using Composer for managing dependencies, then you're doing it wrong and most likely not using this anyway)
* [ ] removes `require_once` statements throughout the code base