### PR TITLE
Fix: Switch to classmap autoloading b/c of missing PSR-0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "ext-curl": "*"
     },
     "autoload": {
-        "psr-0": {
-            "Raygun4php": "src/"
-        }
+        "classmap": [
+          "src/"
+        ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
   xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
   backupGlobals="false"
   backupStaticAttributes="false"
-  bootstrap="testbootstrap.php"
+  bootstrap="vendor/autoload.php"
   colors="true"
   syntaxCheck="false">
   <testsuites>

--- a/testbootstrap.php
+++ b/testbootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once(__DIR__ .'/src/Raygun4php/RaygunClient.php');

--- a/tests/AutoloadingTest.php
+++ b/tests/AutoloadingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+class AutoloadingTest extends PHPUnit_Framework_TestCase
+{
+  /**
+   * @dataProvider providerAvailableClasses
+   *
+   * @param string $className
+   */
+  public function testCanAutoloadClass($className)
+  {
+    $this->assertTrue(class_exists($className), sprintf(
+      'Failed asserting that the class "%s" can be autoloaded.',
+      $className
+    ));
+  }
+
+  /**
+   * @return string[]
+   */
+  public function providerAvailableClasses()
+  {
+    $classNames = array(
+      'Raygun4php\Raygun4PhpException',
+      'Raygun4php\RaygunClient',
+      'Raygun4php\RaygunClientMessage',
+      'Raygun4php\RaygunEnvironmentMessage',
+      'Raygun4php\RaygunExceptionMessage',
+      'Raygun4php\RaygunExceptionTraceLineMessage',
+      'Raygun4php\RaygunIdentifier',
+      'Raygun4php\RaygunMessage',
+      'Raygun4php\RaygunRequestMessage',
+      'Raygun4Php\Rhumsaa\Uuid\Uuid',
+      'Raygun4Php\Rhumsaa\Uuid\Exception\UnsatisfiedDependencyException',
+      'Raygun4Php\Rhumsaa\Uuid\Exception\UnsupportedOperationException',
+    );
+
+    return array_map(function ($className) {
+      return array(
+        $className,
+      );
+    }, $classNames);
+  }
+}


### PR DESCRIPTION
This PR
- [x] modifies `phpunit.xml` to use `vendor\autoload.php` as bootstrapping (should be sufficient)
- [x] adds a failing test to prove PSR-0 autoloading doesn't actually work
- [x] fixes the failure to autoload using PSR-0 by switching to classmap autoloading

Follows #59.

See https://github.com/MindscapeHQ/raygun4php/pull/59#commitcomment-9273155.
