### PR TITLE
Fix: Add test to assert methods w/o visibility keyword are public

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -363,6 +363,9 @@ namespace Raygun4php {
       }
     }
 
+    /**
+     * @todo Method should be private.
+     */
     function toJsonRemoveUnicodeSequences($struct) {
       return preg_replace_callback("/\\\\u([a-f0-9]{4})/", function($matches){ return iconv('UCS-4LE','UTF-8',pack('V', hexdec("U$matches[1]"))); }, json_encode($struct));
     }
@@ -373,6 +376,8 @@ namespace Raygun4php {
      * anonymous functions. Applies to form data, environment data, HTTP headers.
      * Does not apply to GET parameters in the request URI.
      * Filters out raw HTTP data in case any filters are defined, since we can't accurately filter it.
+     *
+     * @todo Method should be private.
      *
      * @param RaygunMessage $message
      * @param  string $replace Value to be inserted by default (unless specified otherwise by custom transformations).

--- a/tests/RaygunClientTest.php
+++ b/tests/RaygunClientTest.php
@@ -124,5 +124,61 @@ class RaygunClientTest extends PHPUnit_Framework_TestCase
 
     return $message;
   }
+
+  public function testToJsonRemoveUnicodeSequences()
+  {
+    $client = new \Raygun4php\RaygunClient('foo');
+
+    $data = array(
+      'bar' => 'baz',
+    );
+
+    $this->assertJson(
+      json_encode($data),
+      $client->toJsonRemoveUnicodeSequences($data)
+    );
+  }
+
+  public function testFilterParamsFromMessage()
+  {
+    $client = new \Raygun4php\RaygunClient('foo');
+
+    $message = $this->getMockBuilder('Raygun4php\RagunMessage')->getMock();
+
+    $this->assertSame(
+      $message,
+      $client->filterParamsFromMessage($message)
+    );
+  }
+
+  public function testCanSetAndFilterParams()
+  {
+    $client = new \Raygun4php\RaygunClient('foo');
+
+    $params = array(
+      'bar' => 'baz',
+    );
+
+    $client->setFilterParams($params);
+
+    $this->assertSame(
+      $params,
+      $client->getFilterParams()
+    );
+  }
+
+  public function testCanSetAndGetProxy()
+  {
+    $client = new \Raygun4php\RaygunClient('foo');
+
+    $proxy = 'bar';
+
+    $client->setProxy($proxy);
+
+    $this->assertSame(
+      $proxy,
+      $client->getProxy()
+    );
+  }
 }
 ?>


### PR DESCRIPTION
Follows #59.

This PR 
- [x] adds tests which assert that the existing methods without declared visibility are `public`ly accessable
- [x] adds todos as methods need to be `private` according to @fundead 

See https://github.com/MindscapeHQ/raygun4php/pull/59#commitcomment-9269836.
