### PR TITLE
Use mb_convert_encoding instead of iconv to drop illegal characters in UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If true is passed in, and **$useAsyncSending** is set to *false*, client->SendEx
 
 You can transmit the version number of your PHP project along with the message by calling `SetVersion()` on your RaygunClient after it is instantiated - this is optional but recommended as the version number is considered to be first-class data for a message.
 
-### User tracking
+### Affected user tracking
 
 **New in 1.5: additional data support**
 

--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -75,7 +75,7 @@ namespace Raygun4php
                     $raw = substr($raw, 0, 4095);
                   }
 
-                  $this->RawData = mb_convert_encoding($raw, 'UTF-8');
+                  $this->RawData = mb_convert_encoding($raw, 'UTF-8', 'UTF-8');
                 }
             }
         }

--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -75,7 +75,7 @@ namespace Raygun4php
                     $raw = substr($raw, 0, 4095);
                   }
 
-                  $this->RawData = iconv('UTF-8', 'UTF-8//IGNORE', $raw);
+                  $this->RawData = mb_convert_encoding($raw, 'UTF-8');
                 }
             }
         }


### PR DESCRIPTION
To drop non-UTF characters in RaygunRequestMessage, `iconv('UTF-8', 'UTF-8//IGNORE', $string)` is used. 

But, the problem is when the from encoding (first argument) and the to encoding (second argument) are identical, this statement throws an error if `$string` has illegal characters.

`mb_convert_encoding()`, in this case, works as expected.

Related Link: http://stackoverflow.com/questions/9375909/iconv-utf-8-ignore-still-produces-illegal-character-error
