### PR TITLE
Add support for nested exceptions

### DIFF
--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -10,6 +10,7 @@ namespace Raygun4php
         public $StackTrace = array();
         public $FileName;
         public $Data;
+        public $InnerError;
 
         public function __construct($exception)
         {
@@ -28,6 +29,11 @@ namespace Raygun4php
             }
 
             $this->FileName = baseName($exception->getFile());
+
+            if ($prev = $exception->getPrevious())
+            {
+                $this->InnerError = new self($prev);
+            }
         }
 
         private function BuildErrorTrace($error)

--- a/tests/RaygunMessageTest.php
+++ b/tests/RaygunMessageTest.php
@@ -26,5 +26,15 @@ class RaygunMessageTest extends PHPUnit_Framework_TestCase
 
     $this->assertEquals($msg->Details->Error->Message, 'Exception: test');
   }
+
+  public function testBuildMessageWithNestedException()
+  {
+    $msg = new \Raygun4php\RaygunMessage();
+
+    $msg->Build(new Exception('outer', 0, new Exception('inner')));
+
+    $this->assertEquals($msg->Details->Error->Message, 'Exception: outer');
+    $this->assertEquals($msg->Details->Error->InnerError->Message, 'Exception: inner');
+  }
 }
 ?>


### PR DESCRIPTION
PHP supports nested exceptions in a similar fashion to many other languages. Whilst not particularly common, they are occasionally useful (e.g. unifying exceptions from different underlying providers) and can be raised by the runtime itself (e.g. throwing an Exception in JsonSerializable::jsonSerialize when called implicitly by json_encode).

The [Raygun API docs](https://raygun.io/docs/integrations/api) describe the innerError field as a string, but both the raygun4net and raygun4py libraries pass an object/hash instead so I've used the same approach here. I've tested this code against our Raygun account and the nested exceptions have been displayed correctly.
