### PR TITLE
Send path when setting cookies

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -210,7 +210,7 @@ namespace Raygun4php {
             $this->cookieTimestamp = time() + 60 * 60 * 24 * 30;
         }
 
-        setcookie($key, $value, $this->cookieTimestamp);
+        setcookie($key, $value, $this->cookieTimestamp, '/');
     }
 
     /*


### PR DESCRIPTION
Calling `setcookie` with an empty `$path` parameter causes the browser to set a cookie using the path of the current request.

For example, `http://example.com/foo/a.php` and `http://example.com/foo/bar/b.php` both instantiate `RaygunClient` with `$disableUserTracking == false`.
If a browser visits these pages, it will have two instances of the `rgisanonymous` cookie stored. One at `/foo` and one at `/foo/bar`.

What we found with this behaviour, is that browsers would hit the max cookie limit (as low as 50 cookies on some browsers) which would cause younger cookies to be replaced.

This fix sets the `$path` parameter to `/` when calling set cookie, so only a single cookie is set per key, per domain.