### PR TITLE
Allow cookie options to be overridden

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -210,7 +210,7 @@ namespace Raygun4php {
             $this->cookieTimestamp = time() + 60 * 60 * 24 * 30;
         }
 
-        setcookie($key, $value, $this->cookieTimestamp);
+        setcookie($key, $value, $this->cookieTimestamp, '/');
     }
 
     /*


### PR DESCRIPTION
Similar rationale to #74 (fixes #66?)

Except:
- `setCookie` is defined as `protected`, so that subclasses can reimplement it
- Other options of [setcookie()](http://php.net/setcookie) are available to be configured
