### PR TITLE
Follow PSR-4 autoloading syntax

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "ext-curl": "*"
     },
     "autoload": {
-        "psr-0": {
-            "Raygun4php": "src/"
+        "psr-4": {
+            "Raygun4php\\": "src/Raygun4php/"
         }
     }
 }


### PR DESCRIPTION
Since [PSR-0 is deprecated](http://www.php-fig.org/psr/psr-0/) as of 2014-10-21, PSR-4 autoloading is the recommended way for registering classes.

Note: Imho this PR would supercede #62.

References:
1. http://www.php-fig.org/psr/psr-0/
2. http://www.php-fig.org/psr/psr-4/
3. https://getcomposer.org/doc/04-schema.md#autoload
