### PR TITLE
Remove echo from RaygunClient

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -356,7 +356,6 @@ namespace Raygun4php {
         {
           $errMsg = "<br/><br/>" . "<strong>Raygun Warning:</strong> Couldn't send asynchronously. ";
           $errMsg .= "Try calling new RaygunClient('apikey', FALSE); to use an alternate sending method, or RaygunClient('key', FALSE, TRUE) to echo the HTTP response" . "<br/><br/>";
-          echo $errMsg;
           trigger_error('httpPost error: ' . $errstr);
           return null;
         }


### PR DESCRIPTION
When RaygunClient cannot communicate with raygun.io, an error is reported using `trigger_error`, which is fine, but the error is also sent back in the response (a page or service request) which is undesirable. 
I suggest to remove the `echo` statement that causes this.
