### PR TITLE
Fix string offset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,8 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
-Generated_Code #added for RIA/Silverlight projects
+# RIA/Silverlight projects
+Generated_Code
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ If, when running a PHP script from the command line on *nix operating systems, y
 
 ## Changelog
 
+- 1.7.1: Fixed illegal string offset
 - 1.7.0: Added custom error grouping
 -	1.6.1: Assign ClassName as exceptionClass
 - 1.6.0: Added HTTP proxy support, support X-Forwarded-For, null server var guards

--- a/src/Raygun4php/RaygunClientMessage.php
+++ b/src/Raygun4php/RaygunClientMessage.php
@@ -10,7 +10,7 @@ namespace Raygun4php
         public function __construct()
         {
             $this->Name = "Raygun4php";
-            $this->Version = "1.7.0";
+            $this->Version = "1.7.1";
             $this->ClientUrl = "https://github.com/MindscapeHQ/raygun4php";
         }
     }

--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -84,7 +84,7 @@ namespace Raygun4php
         {
             if (!function_exists('getallheaders'))
             {
-                $headers = '';
+                $headers = array();
                 foreach ($_SERVER as $name => $value)
                 {
                     if (substr($name, 0, 5) == 'HTTP_')


### PR DESCRIPTION
`RaygunRequestMessage` now creates an array instead of a string. Fixing illegal string offset bug in issue #90 

Also updated versioning & git ignore as per issue #53 