### PR TITLE
Add error bundling to help deal with high traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,83 @@ $client->SetCookieOptions(array(
 ));
 ```
 
+## Error bundling
+
+Error bundling is useful for high traffic and high volumes of errors occurring. Rather than being sent immediately, errors will be sent only after a user-defined threshold has been reached.
+
+The maximum bundle size defaults to 100 with gzip enabled, or 10 with gzip disabled. This can be changed using the `maximumBundleSize` option.
+
+Any errors not sent during the current request can be stored either in session storage (if supported) or on disk to be sent immediately on the next request.
+
+Writing to disk can be toggled using the `writeToDisk` option. Default is false.
+
+### Enable error bundling
+
+```php
+$client = new \Raygun4php\RaygunClient(
+  $key = "API_KEY",
+  $useAsyncSending = true, 
+  $debugSending = true, 
+  $disableUserTracking = false, 
+  $options = array(
+    "bundleErrors" => true,     // Enable error bundling
+    "maximumBundleSize" => 20,  // Set maximum bundle size
+    "gzipBundle" => true,       // Set whether to gzip compress the bundle
+    "writeToDisk" => false      // Write any error messages which didn't send in the previous request to disk
+  )
+);
+```
+
+## Before send callback
+
+Specify a method to be called before the error message data is sent to the API. This method takes one required parameter `RaygunMessage $message`. The $message must be returned.
+
+### Procedural context
+
+```php
+function myCallback($message) {
+  // Manipulate the error message data ...
+  return $message;
+}
+
+$client = new \Raygun4php\RaygunClient(
+  $key = "API_KEY",
+  $useAsyncSending = true, 
+  $debugSending = true, 
+  $disableUserTracking = false, 
+  $options = array(
+    "beforeSendCallback" => "myCallback"
+  )
+);
+```
+
+### Class context
+
+```php 
+require_once 'vendor/autoload.php';
+
+class RaygunSetup {
+  private $client;
+
+  public function __construct() {
+    $this->client = new \Raygun4php\RaygunClient(
+      $key = "API_KEY",
+      $useAsyncSending = true, 
+      $debugSending = true, 
+      $disableUserTracking = false, 
+      $options = array(
+        "beforeSendCallback" => array($this, "myCallback")
+      )
+    );
+  }
+
+  function myCallback($message) {
+    // Manipulate the error message data ...
+    return $message;
+  }
+}
+```
+
 ## Troubleshooting
 
 As above, enable debug mode by instantiating the client with

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -63,6 +63,7 @@ namespace Raygun4php {
     * @param bool $bundleErrors If true, errors will be bundled and sent as a JSON object, useful for high traffic
     * @param int $maxBundleSize The maximum number of errors to include in a bundle before sending. Maximum value is 100 if gzip is enabled, 10 if not enabled
     * @param bool $gzipBundle Gzip compress the JSON bundle before sending
+    * @param bool $encodeData Whether to base64 encode data sent to the API
     * @param bool $writeToDisk Whether to write the bundle overflow to disk, if false, will use session storage if available
     */
     public function __construct($key, $useAsyncSending = true, $debugSending = false, $disableUserTracking = false, $options = array())
@@ -76,6 +77,7 @@ namespace Raygun4php {
         "bundleErrors" => false,
         "maxBundleSize" => 100,
         "gzipBundle" => true,
+        "encodeData" => true,
         "writeToDisk" => false
       );
 
@@ -479,7 +481,10 @@ namespace Raygun4php {
           );
         }
 
-        $curlOpts[] = "-H X-Base64Encoded: true";
+        if($this->settings["encodeData"]) {
+          $curlOpts[] = "-H 'X-Base64Encoded: true'";
+        }
+
         $curlOpts[] = "--cacert '" . realpath(__DIR__ . '/cacert.crt') . "'";
 
         if ($this->proxy) {

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -344,18 +344,16 @@ namespace Raygun4php {
      */
 
     private function flushBundle() {
-      if(isset($_SESSION) && isset($_SESSION["raygun_error_bundle"])) {
-        $sessionBundle = $_SESSION["raygun_error_bundle"];
+      $bundle = $this->bundler->getFromStorage();
 
-        if(is_array($sessionBundle) && !empty($sessionBundle)) {
-          $this->bundler->setBundle($sessionBundle);
+      if(!empty($bundle)) {
+        $this->bundler->setBundle($bundle);
 
-          if(count($sessionBundle) === 1) {
-            $this->Send($sessionBundle[0]);
-          }
-          else {
-            $this->SendBundle($sessionBundle);
-          }
+        if(count($bundle) === 1) {
+          $this->Send($bundle[0]);
+        }
+        else {
+          $this->SendBundle($bundle);
         }
       }
     }

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -461,7 +461,7 @@ namespace Raygun4php {
           $curlOpts = array(
             "-v",
             "-X POST", 
-            "-d \"{$data_to_send}\"",
+            "-d '{$data_to_send}'",
             "-H 'Content-Encoding: gzip'", 
             "-H 'Content-Type: application/gzip'",
             "-H 'X-ApiKey: {$this->apiKey}'",

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -476,6 +476,7 @@ namespace Raygun4php {
           );
         }
 
+        $curlOpts[] = "-H X-Base64Encoded: true";
         $curlOpts[] = "--cacert '" . realpath(__DIR__ . '/cacert.crt') . "'";
 
         if ($this->proxy) {

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -82,7 +82,7 @@ namespace Raygun4php {
       $maxBundleSize = min(100, $settings["maxBundleSize"]);
 
       if($this->bundleErrors) {
-        $this->path = '/bulk/entries';
+        $this->path = '/entries/bulk';
 
         $this->bundler = new \Raygun4php\RaygunErrorBundler(array(
           "maxBundleSize" => $maxBundleSize,

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -462,7 +462,7 @@ namespace Raygun4php {
             "-X POST", 
             "-d '{$data_to_send}'",
             "-H 'Content-Encoding: gzip'", 
-            "-H 'Content-Type: application/gzip'",
+            "-H 'Content-Type: application/x-www-form-urlencoded'",
             "-H 'X-ApiKey: {$this->apiKey}'",
           );
 

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -421,7 +421,11 @@ namespace Raygun4php {
         if ($this->proxy) {
           $curlOpts[] = "--proxy '" . $this->proxy . "'";
         }
-        $cmd = "curl " . implode(' ', $curlOpts) . " 'https://api.raygun.io:443/entries' > /dev/null 2>&1 &";
+
+        $transport = $this->transport === "ssl" ? "https" : "http";
+        $endpoint = "{$transport}://{$this->host}:{$this->port}{$this->path}";
+
+        $cmd = "curl " . implode(' ', $curlOpts) . " '{$endpoint}' > /dev/null 2>&1 &";
         exec($cmd, $output, $exit);
         return $exit;
       }

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -77,19 +77,16 @@ namespace Raygun4php {
         "gzipBundle" => false
       );
 
-      $settings = array_merge($defaults, $options);
+      $this->settings = array_merge($defaults, $options);
 
-      $this->beforeSendCallback = $settings["beforeSendCallback"];
-      $this->bundleErrors = $settings["bundleErrors"];
+      $maxBundleSize = min(100, $this->settings["maxBundleSize"]);
 
-      $maxBundleSize = min(100, $settings["maxBundleSize"]);
-
-      if($this->bundleErrors) {
+      if($this->settings["bundleErrors"]) {
         $this->path = '/entries/bulk';
 
         $this->bundler = new \Raygun4php\RaygunErrorBundler(array(
           "maxBundleSize" => $maxBundleSize,
-          "gzipBundle" => $settings["gzipBundle"]
+          "gzipBundle" => $this->settings["gzipBundle"]
         ));
 
         $this->flushBundle();
@@ -420,7 +417,7 @@ namespace Raygun4php {
       $message = $this->filterParamsFromMessage($message);
       $message = $this->toJsonRemoveUnicodeSequences($message);
 
-      if($this->bundleErrors) {
+      if($this->settings["bundleErrors"]) {
         $this->bundler->addMessage($message);
 
         if($this->bundler->isReadyToSend()) {

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -90,7 +90,7 @@ namespace Raygun4php {
         ));
 
         // Flush any leftover messages stored in the session which weren't bundled
-        if(isset($_SESSION["raygun_error_bundle"])) {
+        if(isset($_SESSION) && isset($_SESSION["raygun_error_bundle"])) {
           $sessionBundle = $_SESSION["raygun_error_bundle"];
 
           if(is_array($sessionBundle) && count($sessionBundle) > 0) {

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -454,13 +454,31 @@ namespace Raygun4php {
 
       if ($this->useAsyncSending && strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')
       {
-        $curlOpts = array(
-          "-X POST",
-          "-H 'Content-Type: application/json'",
-          "-H 'X-ApiKey: " . $this->apiKey . "'",
-          "-d " . escapeshellarg($data_to_send),
-          "--cacert '" . realpath(__DIR__ . '/cacert.crt') . "'"
-        );
+        $curlOpts = array();
+
+        if($this->settings["gzipBundle"]) {
+
+          $curlOpts = array(
+            "-v",
+            "-X POST", 
+            "-d \"{$data_to_send}\"",
+            "-H 'Content-Encoding: gzip'", 
+            "-H 'Content-Type: application/gzip'",
+            "-H 'X-ApiKey: {$this->apiKey}'",
+          );
+
+        }
+        else {
+          $curlOpts = array(
+            "-X POST",
+            "-H 'Content-Type: application/json'",
+            "-H 'X-ApiKey: {$this->apiKey}'",
+            "-d " . escapeshellarg($data_to_send),
+          );
+        }
+
+        $curlOpts[] = "--cacert '" . realpath(__DIR__ . '/cacert.crt') . "'";
+
         if ($this->proxy) {
           $curlOpts[] = "--proxy '" . $this->proxy . "'";
         }

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -1,6 +1,5 @@
-<?php
+<?php 
 namespace Raygun4php {
-  session_start();
   require_once realpath(__DIR__ . '/RaygunMessage.php');
   require_once realpath(__DIR__ . '/RaygunIdentifier.php');
   require_once realpath(__DIR__ . '/Raygun4PhpException.php');
@@ -84,10 +83,7 @@ namespace Raygun4php {
       if($this->settings["bundleErrors"]) {
         $this->path = '/entries/bulk';
 
-        $this->bundler = new \Raygun4php\RaygunErrorBundler(array(
-          "maxBundleSize" => $maxBundleSize,
-          "gzipBundle" => $this->settings["gzipBundle"]
-        ));
+        $this->bundler = new \Raygun4php\RaygunErrorBundler($this->settings);
 
         $this->flushBundle();
       }

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -492,10 +492,12 @@ namespace Raygun4php {
         }
 
         $transport = $this->transport === "ssl" ? "https" : "http";
-        $endpoint = "{$transport}://{$this->host}:{$this->port}{$this->path}";
+        $endpoint = "{$transport}://{$this->host}{$this->path}";
 
         $cmd = "curl " . implode(' ', $curlOpts) . " '{$endpoint}' > /dev/null 2>&1 &";
+
         exec($cmd, $output, $exit);
+        
         return $exit;
       }
       else

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -459,7 +459,6 @@ namespace Raygun4php {
         if($this->settings["gzipBundle"]) {
 
           $curlOpts = array(
-            "-v",
             "-X POST", 
             "-d '{$data_to_send}'",
             "-H 'Content-Encoding: gzip'", 

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -74,7 +74,7 @@ namespace Raygun4php {
         "beforeSendCallback" => null,
         "bundleErrors" => false,
         "maxBundleSize" => 100,
-        "gzipBundle" => false
+        "gzipBundle" => true
       );
 
       $this->settings = array_merge($defaults, $options);

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -63,6 +63,7 @@ namespace Raygun4php {
     * @param bool $bundleErrors If true, errors will be bundled and sent as a JSON object, useful for high traffic
     * @param int $maxBundleSize The maximum number of errors to include in a bundle before sending. Maximum value is 100 if gzip is enabled, 10 if not enabled
     * @param bool $gzipBundle Gzip compress the JSON bundle before sending
+    * @param bool $writeToDisk Whether to write the bundle overflow to disk, if false, will use session storage if available
     */
     public function __construct($key, $useAsyncSending = true, $debugSending = false, $disableUserTracking = false, $options = array())
     {
@@ -74,7 +75,8 @@ namespace Raygun4php {
         "beforeSendCallback" => null,
         "bundleErrors" => false,
         "maxBundleSize" => 100,
-        "gzipBundle" => true
+        "gzipBundle" => true,
+        "writeToDisk" => false
       );
 
       $this->settings = array_merge($defaults, $options);

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -41,7 +41,7 @@ namespace Raygun4php
       $bundleString = "[{$bundleString}]";
 
       if($this->settings["gzipBundle"]) {
-        $bundleString = gzcompress($bundleString, $this->settings["gzipLevel"]);
+        $bundleString = gzencode($bundleString, $this->settings["gzipLevel"]);
       }
 
       return base64_encode($bundleString);

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -44,7 +44,7 @@ namespace Raygun4php
         $bundleString = gzcompress($bundleString, $this->settings["gzipLevel"]);
       }
 
-      return $bundleString;
+      return base64_encode($bundleString);
     }
 
     public function reset() {

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -34,13 +34,17 @@ namespace Raygun4php
     }
 
     public function getJson() {
-      $json = json_encode($this->getBundle());
+      $bundle = $this->getBundle();
+
+      // Manually convert to JSON to prevent double-encoding
+      $bundleString = implode(",", $bundle);
+      $bundleString = "[{$bundleString}]";
 
       if($this->settings["gzipBundle"]) {
-        $json = gzcompress($json, $this->settings["gzipLevel"]);
+        $bundleString = gzcompress($bundleString, $this->settings["gzipLevel"]);
       }
 
-      return $json;
+      return $bundleString;
     }
 
     public function reset() {

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -12,7 +12,8 @@ namespace Raygun4php
         "maxBundleSize" => 100,
         "expiryInSeconds" => 60,
         "gzipBundle" => false,
-        "gzipLevel" => 6
+        "gzipLevel" => 6,
+        "encodeData" => true
       );
 
       $this->settings = array_merge($defaults, $options);
@@ -44,7 +45,11 @@ namespace Raygun4php
         $bundleString = gzencode($bundleString, $this->settings["gzipLevel"]);
       }
 
-      return base64_encode($bundleString);
+      if($this->settings["encodeData"]) {
+        $bundleString = base64_encode($bundleString);
+      }
+
+      return $bundleString;
     }
 
     public function reset() {

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -57,6 +57,17 @@ namespace Raygun4php
       return count($this->getBundle()) >= $this->settings["maxBundleSize"] || $this->isBundleExpired();
     }
 
+    public function getFromStorage() {
+      if(isset($_SESSION) && isset($_SESSION["raygun_error_bundle"])) {
+        $sessionBundle = $_SESSION["raygun_error_bundle"];
+
+        if(is_array($sessionBundle) && !empty($sessionBundle)) {
+          return $sessionBundle;
+        }
+      }
+
+      return false;
+    }
     private function isBundleExpired() {
       return (time() - $this->startTime) > $this->settings["expiryInSeconds"];
     }

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -14,8 +14,17 @@ namespace Raygun4php
       $this->startTime = time();
     }
 
+    public function getBundle() {
+      return $this->bundle;
+    }
+
+    public function setBundle($bundle = array()) {
+      $this->bundle = $bundle;
+    }
+
     public function addMessage($message) {
       $this->bundle[] = $message;
+      $_SESSION["raygun_error_bundle"] = $this->bundle;
     }
 
     public function getJson() {
@@ -24,7 +33,8 @@ namespace Raygun4php
 
     public function reset() {
       $this->startTime = time();
-      $this->bundle = array();
+      $this->setBundle(array());
+      $_SESSION["raygun_error_bundle"] = array();
     }
 
     public function isReadyToSend() {

--- a/src/Raygun4php/RaygunErrorBundler.php
+++ b/src/Raygun4php/RaygunErrorBundler.php
@@ -1,0 +1,41 @@
+<?php 
+
+namespace Raygun4php
+{
+  class RaygunErrorBundler {
+    private $bundle = array();
+    private $startTime;
+    private $maxBundleSize;
+    private $expiryInSeconds;
+
+    public function __construct($options = array()) {
+      $this->maxBundleSize = isset($options["maxBundleSize"]) ? $options["maxBundleSize"] : 100;
+      $this->expiryInSeconds = isset($options["expiryInSeconds"]) ? $options["expiryInSeconds"] : 60;
+      $this->startTime = time();
+    }
+
+    public function addMessage($message) {
+      $this->bundle[] = $message;
+    }
+
+    public function getJson() {
+      return json_encode($this->bundle);
+    }
+
+    public function reset() {
+      $this->startTime = time();
+      $this->bundle = array();
+    }
+
+    public function isReadyToSend() {
+      return count($this->bundle) >= $this->maxBundleSize || $this->isBundleExpired();
+    }
+
+    private function isBundleExpired() {
+      $currentTimestamp = time();
+
+      return ($currentTimestamp - $this->startTime) > $this->expiryInSeconds;
+    }
+
+  }
+}


### PR DESCRIPTION
### Updates

- Add a bundler class which populates an array with incoming messages
- Send a bundle after certain conditions have been met. Either the number of messages in the bundle reaches the maximum bundle size (default 100) or after a time period (default 60s)
- Post bundle to the bundle entries endpoint on the API