### PR TITLE
Raygun4PHP: Remove echo when socket connection fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,8 +306,8 @@ function error_handler($errno, $errstr, $errfile, $errline ) {
 See the [Error Control Operators section on PHP.net](http://php.net/manual/en/language.operators.errorcontrol.php) for more information  
 
 ## Changelog
-
-- 1.8.1: Fix issue with error being raised with null bytes send with escapeshellarg method 
+- 1.8.2: No longer output warning when a socket connection fails 
+- 1.8.1: Fix issue with error being raised with null bytes send with escapeshellarg method
 - 1.8.0: Bugfix with multiple cookies being set. Cookie options can be set via the setCookieOptions method
 - 1.7.1: Fixed illegal string offset
 - 1.7.0: Added custom error grouping

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -408,8 +408,9 @@ namespace Raygun4php {
         else
         {
           if($this->debug) {
-            $errMsg = "<br/><br/>" . "<strong>Raygun Warning:</strong> Couldn't send asynchronously. ";
-            $errMsg .= "Try calling new RaygunClient('apikey', FALSE); to use an alternate sending method, or RaygunClient('key', FALSE, TRUE) to echo the HTTP response" . "<br/><br/>";
+            $errMsg = "<br/><br/>" . "<strong>Raygun Warning:</strong> Couldn't send error. ";
+            $errMsg .= "Error number: " . $errno . "<br/><br/>";
+            $errMsg .= "Error string: " . $errstr . "<br/><br/>";
             echo $errMsg;
           }
           trigger_error('httpPost error: ' . $errstr);

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -347,6 +347,8 @@ namespace Raygun4php {
           $curlOpts[] = "--proxy '" . $this->proxy . "'";
         }
         $cmd = "curl " . implode(' ', $curlOpts) . " 'https://api.raygun.io:443/entries' > /dev/null 2>&1 &";
+        $output = array();
+        $exit;
         exec($cmd, $output, $exit);
         return $exit;
       }

--- a/src/Raygun4php/RaygunClientMessage.php
+++ b/src/Raygun4php/RaygunClientMessage.php
@@ -10,7 +10,7 @@ namespace Raygun4php
         public function __construct()
         {
             $this->Name = "Raygun4php";
-            $this->Version = "1.8.1";
+            $this->Version = "1.8.2";
             $this->ClientUrl = "https://github.com/MindscapeHQ/raygun4php";
         }
     }


### PR DESCRIPTION
Only outputs socket connection errors when debug mode is enabled. Previous it would echo out a warning when the connection failed which isn't desired in production environments.  