### PR TITLE
Fix regression, Guard against accessing unset user id

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -257,7 +257,7 @@ namespace Raygun4php {
       {
         $message->Details->User = new RaygunIdentifier($this->user, $this->firstName, $this->fullName, $this->email, $this->isAnonymous, $this->uuid);
       }
-      else if (!$this->disableUserTracking)
+      else if (!$this->disableUserTracking && array_key_exists('rguserid', $_COOKIE))
       {
         $message->Details->User = new RaygunIdentifier($_COOKIE['rguserid']);
       }


### PR DESCRIPTION
Originally fixed in https://github.com/MindscapeHQ/raygun4php/commit/60ba178d418cb6ae75db6aeb0f945a693d1c44cf

We have just hit this error running hash - 6d28cbb05ce6ba703fefc726c4b95087c774153b

PHP Fatal error:  Uncaught exception 'ErrorException' with message 'Undefined index: rguserid' in /my/web/root/vendor/mindscape/raygun4php/src/Raygun4php/RaygunClient.php:262