### PR TITLE
In RaygunClient add setter and getter for disableUserTracking

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -74,6 +74,24 @@ namespace Raygun4php {
     }
 
     /**
+     * @param bool $disableUserTracking True to disable user tracking
+     * @return $this
+     */
+    public function setDisableUserTracking($disableUserTracking)
+    {
+        $this->disableUserTracking = $disableUserTracking;
+        return $this;
+    }
+
+    /**
+     * @return bool Returns true if user tracking is disabled
+     */
+    public function getDisableUserTracking()
+    {
+        return $this->disableUserTracking;
+    }
+
+    /**
      * Transmits an error to the Raygun.io API
      *
      * @param int    $errno          The error number


### PR DESCRIPTION
Add a **setter** and a **getter** for **disableUserTracking** to allow enable and disable tracking of anonymous users programatically after instantiation of the RaygunClient.

This is especially useful, if a RaygunClient is instantiated in an error handler and the cookie should only be set when an error actually occurs. The _SetUser_ method then can be called manually potentially with an actual user information (the current implementation safeguards cookies from being set if the headers have been sent already).