### PR TITLE
Fix docblock datatypes and remove deprecated composer option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ php: [5.4, 5.5, 7.0]
 
 before_script:
   - composer self-update
-  - composer install --dev --prefer-source --no-interaction --no-progress
+  - composer install --prefer-source --no-interaction --no-progress
 
 script: 'vendor/bin/phpunit tests'

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -36,7 +36,7 @@ namespace Raygun4php {
     );
 
     /**
-     * @var Array Parameter names to filter out of logged form data. Case insensitive.
+     * @var array Parameter names to filter out of logged form data. Case insensitive.
      * Accepts regular expressions when the name starts with a forward slash.
      * Maps either to TRUE, or to a callable with $key and $value arguments.
      */
@@ -489,7 +489,7 @@ namespace Raygun4php {
     }
 
     /**
-     * @param Array $params
+     * @param array $params
      * @return Raygun4php\RaygunClient
      */
     function setFilterParams($params) {
@@ -498,7 +498,7 @@ namespace Raygun4php {
     }
 
     /**
-     * @return Array
+     * @return array
      */
     function getFilterParams() {
       return $this->filterParams;


### PR DESCRIPTION
Two minor non-functional changes:
- `Array` -> `array` in some docblocks to get IDEs to stop complaining about an unknown class.
- Removed the `--dev` option to composer to avoid this message:
```
You are using the deprecated option "dev". Dev packages are installed by default now.
```