### PR TITLE
Fix: Limit ranges of PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "keywords": ["raygun", "errors", "exceptions", "logging"],
     "license": "MIT",
     "require": {
-        "php": ">=5.4.0"
+        "php": "^5.4 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.16"


### PR DESCRIPTION
This P

* [x] limits the range of PHP versions this project can be installed with

💁‍♂️ We don't know yet whether this project will be compatible with PHP 9000.