### PR TITLE
Use Throwable interface instead of Exception

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -129,7 +129,7 @@ class RaygunClient
     /**
      * Transmits an exception to the Raygun.io API
      *
-     * @param \Exception $exception      An exception object to transmit
+     * @param \Throwable $throwable      An exception object to transmit
      * @param array      $tags           An optional array of string tags used to provide metadata for the message
      * @param array      $userCustomData An optional associative array that can be used to place custom key-value
      *                                   data in the message payload
@@ -137,9 +137,9 @@ class RaygunClient
      *                                   occurred.
      * @return int The HTTP status code of the result when transmitting the message to Raygun.io
      */
-    public function SendException($exception, $tags = null, $userCustomData = null, $timestamp = null)
+    public function SendException($throwable, $tags = null, $userCustomData = null, $timestamp = null)
     {
-        $message = $this->BuildMessage($exception, $timestamp);
+        $message = $this->BuildMessage($throwable, $timestamp);
 
         if ($tags != null) {
             $this->AddTags($message, $tags);
@@ -289,7 +289,7 @@ class RaygunClient
     }
 
     /**
-     * @param \Exception $errorException
+     * @param \Throwable $errorException
      * @param int $timestamp
      * @return RaygunMessage
      */

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -11,6 +11,9 @@ class RaygunExceptionMessage
     public $Data;
     public $InnerError;
 
+    /**
+     * @param \Throwable $exception
+     */
     public function __construct($exception)
     {
         $exceptionClass = get_class($exception);

--- a/src/Raygun4php/RaygunMessage.php
+++ b/src/Raygun4php/RaygunMessage.php
@@ -16,6 +16,9 @@ class RaygunMessage
         $this->Details = new RaygunMessageDetails();
     }
 
+    /**
+     * @param \Throwable $exception
+     */
     public function Build($exception)
     {
         $this->Details->MachineName = gethostname();


### PR DESCRIPTION
Symfony has deprecated its `Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent::getException()` in favour of `getThrowable()`. This causes some issues with static analysis when `RaygunClient::SendException()` is expecting `Exception` but `getThrowable()` returns `Throwable`.

By changing out the types in `RaygunClient` etc it allows for `Throwable` and anything that implements it, such as `Exception`, `Error` etc.