### PR TITLE
Psr3 logging trasports

### DIFF
--- a/UsageExampleV2.md
+++ b/UsageExampleV2.md
@@ -16,9 +16,7 @@ $httpClient = new GuzzleHttp\Client([
 
 // If synchronous message delivery is wanted use Raygun4php\Transports\GuzzleSync
 $transport = new Raygun4php\Transports\GuzzleAsync($httpClient);
-
 $client = new Raygun4php\RaygunClient($transport);
-
 
 // Create and register error handlers
 function error_handler($errno, $errstr, $errfile, $errline )
@@ -47,9 +45,17 @@ function fatal_error()
     }
 }
 
-    set_exception_handler('exception_handler');
-    set_error_handler("error_handler");
-    register_shutdown_function("fatal_error");
+function flush_on_shutdown()
+{
+    global $transport;
+    $transport->wait();
+}
 
+set_exception_handler('exception_handler');
+set_error_handler("error_handler");
+register_shutdown_function("fatal_error");
+
+// This is needed to if guzzleAsync is used as transport to make sure all request are resolved.
+register_shutdown_function("flush_on_shutdown");
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/src/Raygun4php/Transports/GuzzleAsync.php
+++ b/src/Raygun4php/Transports/GuzzleAsync.php
@@ -82,7 +82,7 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
         $this->logger = $logger;
     }
 
-    public function wait()
+    public function wait(): void
     {
         Promise\settle($this->httpPromises)->wait(false);
     }

--- a/src/Raygun4php/Transports/GuzzleAsync.php
+++ b/src/Raygun4php/Transports/GuzzleAsync.php
@@ -82,7 +82,7 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
         $this->logger = $logger;
     }
 
-    public function __destruct()
+    public function wait()
     {
         Promise\settle($this->httpPromises)->wait(false);
     }

--- a/src/Raygun4php/Transports/GuzzleAsync.php
+++ b/src/Raygun4php/Transports/GuzzleAsync.php
@@ -42,7 +42,7 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
 
     /**
      * Asynchronously transmits the message to the raygun API.
-     * Relies on the destructor of this object to settle any pending requests.
+     * Relies on the wait() method of this object being called to settle any pending requests.
      *
      * @param RaygunMessageInterface $message
      * @return boolean
@@ -77,11 +77,22 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
         return true;
     }
 
-    public function setLogger(LoggerInterface $logger)
+    /**
+     * @param LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
+    /**
+     * Calling this method will settle any pending request.
+     * Calling this method should typically handled by a function registered as a shutdown function.
+     * @see https://www.php.net/manual/en/function.register-shutdown-function.php
+     *
+     * @return void
+     */
     public function wait(): void
     {
         Promise\settle($this->httpPromises)->wait(false);

--- a/src/Raygun4php/Transports/GuzzleAsync.php
+++ b/src/Raygun4php/Transports/GuzzleAsync.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Promise;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class GuzzleAsync implements TransportInterface, LoggerAwareInterface
 {
@@ -36,6 +37,7 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
     public function __construct(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -82,6 +84,6 @@ class GuzzleAsync implements TransportInterface, LoggerAwareInterface
 
     public function __destruct()
     {
-        Promise\settle($this->httpPromises)->wait();
+        Promise\settle($this->httpPromises)->wait(false);
     }
 }

--- a/src/Raygun4php/Transports/GuzzleSync.php
+++ b/src/Raygun4php/Transports/GuzzleSync.php
@@ -6,9 +6,17 @@ use Raygun4php\Interfaces\RaygunMessageInterface;
 use Raygun4php\Interfaces\TransportInterface;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\TransferException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
-class GuzzleSync implements TransportInterface
+class GuzzleSync implements TransportInterface, LoggerAwareInterface
 {
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
     /**
      * @var ClientInterface
      */
@@ -21,6 +29,7 @@ class GuzzleSync implements TransportInterface
     public function __construct(ClientInterface $httpClient)
     {
         $this->httpClient = $httpClient;
+        $this->logger = new NullLogger();
     }
 
     /**
@@ -37,10 +46,29 @@ class GuzzleSync implements TransportInterface
             $httpResponse = $this->httpClient
                                  ->request('POST', '/entries', ['body' => $messageJson]);
         } catch (TransferException $th) {
+            $this->logger->error($th->getMessage(), json_decode($messageJson, true));
             return false;
         }
 
         $responseCode = $httpResponse->getStatusCode();
-        return $responseCode === 202;
+
+        if ($responseCode !== 202) {
+            $logMsg = "Expected response code 202 but got {$responseCode}";
+            if ($responseCode < 400) {
+                $this->logger->warning($logMsg, json_decode($messageJson, true));
+            } else {
+                $this->logger->error($logMsg, json_decode($messageJson, true));
+            }
+            return false;
+        }
+        return true;
     }
+
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+
+    
 }

--- a/src/Raygun4php/Transports/GuzzleSync.php
+++ b/src/Raygun4php/Transports/GuzzleSync.php
@@ -68,7 +68,4 @@ class GuzzleSync implements TransportInterface, LoggerAwareInterface
     {
         $this->logger = $logger;
     }
-
-
-    
 }

--- a/src/Raygun4php/Transports/GuzzleSync.php
+++ b/src/Raygun4php/Transports/GuzzleSync.php
@@ -64,7 +64,11 @@ class GuzzleSync implements TransportInterface, LoggerAwareInterface
         return true;
     }
 
-    public function setLogger(LoggerInterface $logger)
+    /**
+     * @param LoggerInterface $logger
+     * @return void
+     */
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }

--- a/tests/Transports/GuzzleAsyncTest.php
+++ b/tests/Transports/GuzzleAsyncTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Raygun4php\Tests\Transports;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\Test\TestLogger;
+use Raygun4php\RaygunMessage;
+use Raygun4php\Transports\GuzzleAsync;
+
+class GuzzleAsyncTest extends TestCase
+{
+
+    public function testTransmitLogsErrorIfResponseCodeIs400()
+    {
+        $mock = new MockHandler([
+            new Response(400)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleAsync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+        $transport->__destruct();
+
+        $this->assertTrue($logger->hasErrorRecords());
+    }
+
+    public function testTransmitLogsWarningIfResponseCodeIs200()
+    {
+        $mock = new MockHandler([
+            new Response(200)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleAsync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+        $transport->__destruct();
+
+        $this->assertTrue($logger->hasWarningRecords());
+    }
+
+    public function testTransmitLogsErrorIfHttpClientThrowsException()
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection failed', new Request('POST', 'test'))
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleAsync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+        $transport->__destruct();
+
+        $this->assertTrue($logger->hasErrorRecords());
+    }
+}

--- a/tests/Transports/GuzzleAsyncTest.php
+++ b/tests/Transports/GuzzleAsyncTest.php
@@ -32,7 +32,7 @@ class GuzzleAsyncTest extends TestCase
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-        $transport->__destruct();
+        $transport->wait();
 
         $this->assertTrue($logger->hasErrorRecords());
     }
@@ -53,7 +53,7 @@ class GuzzleAsyncTest extends TestCase
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-        $transport->__destruct();
+        $transport->wait();
 
         $this->assertTrue($logger->hasWarningRecords());
     }
@@ -74,7 +74,7 @@ class GuzzleAsyncTest extends TestCase
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-        $transport->__destruct();
+        $transport->wait();
 
         $this->assertTrue($logger->hasErrorRecords());
     }

--- a/tests/Transports/GuzzleSyncTest.php
+++ b/tests/Transports/GuzzleSyncTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Raygun4php\Tests\Transports;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\Test\TestLogger;
+use Raygun4php\RaygunMessage;
+use Raygun4php\Transports\GuzzleSync;
+
+class GuzzleSyncTest extends TestCase
+{
+    public function testTransmitReturnsTrueIfResponseCodeIs202()
+    {
+        $mock = new MockHandler([
+            new Response(202)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $this->assertTrue($transport->transmit($message));
+    }
+
+    public function testTransmitReturnsFalseIfResponseIs400()
+    {
+        $mock = new MockHandler([
+            new Response(400)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $this->assertFalse($transport->transmit($message));
+    }
+
+    public function testTransmitReturnsFalsIfHttpClientThrowsException()
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection failed', new Request('POST', 'test'))
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $this->assertFalse($transport->transmit($message));
+    }
+
+    public function testTransmitLogsErrorIfHttpClientThrowsException()
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection failed', new Request('POST', 'test'))
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+
+        $this->assertTrue($logger->hasErrorRecords());
+    }
+
+    public function testTransmitLogsRelevant400Message()
+    {
+        $mock = new MockHandler([
+            new Response(400)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler, 'base_uri' => 'https://api.raygun.io']);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+
+        $this->assertTrue($logger->hasErrorThatContains('400'));
+    }
+
+    public function testTransmitLogsRelevant400MessageNoException()
+    {
+        $mock = new MockHandler([
+            new Response(400)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler,
+                              'base_uri' => 'https://api.raygun.io',
+                              'http_error' => false
+                              ]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+
+        $this->assertTrue($logger->hasErrorThatContains('400'));
+    }
+
+    public function testTransmitLogsRelevant403Message()
+    {
+        $mock = new MockHandler([
+            new Response(403)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler, 'base_uri' => 'https://api.raygun.io']);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $logger = new TestLogger();
+        $transport->setLogger($logger);
+
+        $transport->transmit($message);
+
+        $this->assertTrue($logger->hasErrorThatContains('403'));
+    }
+
+    public function testTransmitReturnsFalseOnHttpStatus400NoException()
+    {
+        $mock = new MockHandler([
+            new Response(400)
+        ]);
+
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler, 'http_errors' => false]);
+
+        $transport = new GuzzleSync($client);
+        $message = new RaygunMessage();
+
+        $this->assertFalse($transport->transmit($message));
+    }
+}


### PR DESCRIPTION
Adds PSR-3 logging to both transports.

Changes the way the async transport handles waiting for all requests (promises) to be resolved before the script exits.
Using the destructor was a bit flaky, and is now replaced with a method called `wait()`, calling `wait() `should be handled by registering a shutdown function.


There is not much more than that to this PR!

**Happy Saint Lucy's Day!**
