### PR TITLE
Add PHP Versions to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
 before_script:
   - composer self-update
+  - if [[ ${TRAVIS_PHP_VERSION:0:3} =~ ^7\.[234]$ ]] ; then composer require --dev phpunit/phpunit:"^5.7.27" ; fi
   - composer install --prefer-source --no-interaction --no-progress
 
 script: 'vendor/bin/phpunit tests'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 dist: trusty
 
-php: [5.4, 5.5, 7.0]
+php: [5.4, 5.5, 5.6, 7.0, 7.1, 7.2, 7.3, 7.4]
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.16"
+        "phpunit/phpunit": "^5.7.27"
     },
     "suggest": {
         "ext-curl": "*"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.27"
+        "phpunit/phpunit": "^4.8.16"
     },
     "suggest": {
         "ext-curl": "*"


### PR DESCRIPTION
- I've added up to 7.4. I didn't know which PHP version to support.

- Updating PHPUnit. The reason is to avoid the following deprecation warning in PHP version 7.2 or higher

```
PHP Deprecated:  The each() function is deprecated. This message will be suppressed on further calls in /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
PHP Stack trace:
PHP   1. {main}() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/phpunit:52
PHP   3. PHPUnit_TextUI_Command->run() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/src/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_Command->handleArguments() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/src/TextUI/Command.php:111
PHP   5. PHPUnit_Util_Getopt::getopt() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/src/TextUI/Command.php:240
PHP   6. each() /home/travis/build/tenkoma/raygun4php/vendor/phpunit/phpunit/src/Util/Getopt.php:38
```