### PR TITLE
Add a convenient wrapper class with defaults to simplify setup

### DIFF
--- a/sample-apps/.gitignore
+++ b/sample-apps/.gitignore
@@ -1,2 +1,3 @@
 debug.log
 config.php
+logs

--- a/sample-apps/async-example/raygunSetup.php
+++ b/sample-apps/async-example/raygunSetup.php
@@ -80,7 +80,7 @@ namespace {
 
             if (!is_null($lastError)) {
                 [$type, $message, $file, $line] = $lastError;
-                $this->logger->info('Fatal error', [$type, $message]);
+                $this->logger->error('Fatal error', [$type, $message]);
 
                 $tags = array_merge($this->tags, ['fatal-error']);
                 $this->raygunClient->SendError($type, $message, $file, $line, $tags);

--- a/sample-apps/async-example/raygunSetup.php
+++ b/sample-apps/async-example/raygunSetup.php
@@ -2,15 +2,8 @@
 
 namespace {
     require_once 'vendor/autoload.php';
+    require_once '../../vendor/autoload.php';
     require_once 'config.php';
-
-    // Needed during development
-    require_once '../../src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/Interfaces/HttpClientFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/TransportFactory.php';
-    require_once '../../src/Raygun4php/Factories/HttpClientFactory.php';
-    require_once '../../src/Raygun4php/Factories/RaygunClientFactory.php';
 
     use Monolog\Logger;
     use Monolog\Handler\StreamHandler;

--- a/sample-apps/sync-example/raygunSetup.php
+++ b/sample-apps/sync-example/raygunSetup.php
@@ -2,15 +2,8 @@
 
 namespace {
     require_once 'vendor/autoload.php';
+    require_once '../../vendor/autoload.php';
     require_once 'config.php';
-
-    // Needed during development
-    require_once '../../src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/Interfaces/HttpClientFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php';
-    require_once '../../src/Raygun4php/Factories/TransportFactory.php';
-    require_once '../../src/Raygun4php/Factories/HttpClientFactory.php';
-    require_once '../../src/Raygun4php/Factories/RaygunClientFactory.php';
 
     use Monolog\Handler\FirePHPHandler;
     use Monolog\Handler\StreamHandler;

--- a/src/Raygun4php/Factories/HttpClientFactory.php
+++ b/src/Raygun4php/Factories/HttpClientFactory.php
@@ -42,7 +42,7 @@ class HttpClientFactory implements HttpClientFactoryInterface
      * @param string|null $proxy
      * @return ClientInterface
      */
-    private function buildInternal(float $timeout = self::DEFAULT_TIMEOUT, string $proxy = null): ClientInterface
+    private function buildInternal(?float $timeout = self::DEFAULT_TIMEOUT, string $proxy = null): ClientInterface
     {
         $httpClient = new Client([
             'base_uri' => self::BASE_URI,

--- a/src/Raygun4php/Factories/HttpClientFactory.php
+++ b/src/Raygun4php/Factories/HttpClientFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Raygun4php\Factories;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use Raygun4php\Factories\Interfaces\HttpClientFactoryInterface;
+
+class HttpClientFactory implements HttpClientFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    const BASE_URI = 'https://api.raygun.com';
+    const DEFAULT_TIMEOUT = 2.0;
+
+    /**
+     * HttpClientFactory
+     *
+     * Build a Guzzle HTTP client to transmit data with. Base URI set as constant to hide from top-level
+     *
+     * @param string $apiKey
+     */
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @param float|null $timeout
+     * @return ClientInterface
+     */
+    public function build(?float $timeout = self::DEFAULT_TIMEOUT, string $proxy = null): ClientInterface
+    {
+        return $this->buildInternal($timeout, $proxy);
+    }
+
+    /**
+     * @param float $timeout
+     * @param string|null $proxy
+     * @return ClientInterface
+     */
+    private function buildInternal(float $timeout = self::DEFAULT_TIMEOUT, string $proxy = null): ClientInterface
+    {
+        $httpClient = new Client([
+            'base_uri' => self::BASE_URI,
+            'timeout' => $timeout,
+            'headers' => [
+                'X-ApiKey' => $this->apiKey
+            ]
+        ]);
+
+        if (!is_null($proxy)) {
+            $httpClient['proxy'] = $proxy;
+        }
+
+        return $httpClient;
+    }
+}

--- a/src/Raygun4php/Factories/HttpClientFactory.php
+++ b/src/Raygun4php/Factories/HttpClientFactory.php
@@ -13,8 +13,8 @@ class HttpClientFactory implements HttpClientFactoryInterface
      */
     private $apiKey;
 
-    const BASE_URI = 'https://api.raygun.com';
-    const DEFAULT_TIMEOUT = 2.0;
+    private const BASE_URI = 'https://api.raygun.com';
+    private const DEFAULT_TIMEOUT = 2.0;
 
     /**
      * HttpClientFactory

--- a/src/Raygun4php/Factories/Interfaces/HttpClientFactoryInterface.php
+++ b/src/Raygun4php/Factories/Interfaces/HttpClientFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Raygun4php\Factories\Interfaces;
+
+use GuzzleHttp\ClientInterface;
+
+interface HttpClientFactoryInterface
+{
+    public function build(?float $timeout, string $proxy): ClientInterface;
+}

--- a/src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php
+++ b/src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php
@@ -9,6 +9,8 @@ use Raygun4php\RaygunClient;
 interface RaygunClientFactoryInterface
 {
     public function setLogger(LoggerInterface $logger): RaygunClientFactory;
+    public function setProxy(string $proxy): RaygunClientFactory;
+    public function setTimeout(float $timeout): RaygunClientFactory;
 
     public function build(): RaygunClient;
 }

--- a/src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php
+++ b/src/Raygun4php/Factories/Interfaces/RaygunClientFactoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Raygun4php\Factories\Interfaces;
+
+use Psr\Log\LoggerInterface;
+use Raygun4php\Factories\RaygunClientFactory;
+use Raygun4php\RaygunClient;
+
+interface RaygunClientFactoryInterface
+{
+    public function setLogger(LoggerInterface $logger): RaygunClientFactory;
+
+    public function build(): RaygunClient;
+}

--- a/src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php
+++ b/src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Raygun4php\Factories\Interfaces;
+
+use Raygun4php\Interfaces\TransportInterface;
+
+interface TransportFactoryInterface
+{
+    public function build(): TransportInterface;
+}

--- a/src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php
+++ b/src/Raygun4php/Factories/Interfaces/TransportFactoryInterface.php
@@ -6,5 +6,5 @@ use Raygun4php\Interfaces\TransportInterface;
 
 interface TransportFactoryInterface
 {
-    public function build(): TransportInterface;
+    public function build(?float $timeout, $proxy): TransportInterface;
 }

--- a/src/Raygun4php/Factories/RaygunClientFactory.php
+++ b/src/Raygun4php/Factories/RaygunClientFactory.php
@@ -65,7 +65,8 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
      * @param string $proxy
      * @return RaygunClientFactory
      */
-    public function setProxy(string $proxy): RaygunClientFactory {
+    public function setProxy(string $proxy): RaygunClientFactory
+    {
         $this->proxy = $proxy;
 
         return $this;
@@ -75,7 +76,8 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
      * @param float $timeout
      * @return RaygunClientFactory
      */
-    public function setTimeout(float $timeout): RaygunClientFactory {
+    public function setTimeout(float $timeout): RaygunClientFactory
+    {
         $this->timeout = $timeout;
 
         return $this;

--- a/src/Raygun4php/Factories/RaygunClientFactory.php
+++ b/src/Raygun4php/Factories/RaygunClientFactory.php
@@ -25,7 +25,13 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
      * @var bool
      */
     private $disableUserTracking;
+    /**
+     * @var string
+     */
     private $proxy;
+    /**
+     * @var float
+     */
     private $timeout;
 
     /**
@@ -55,12 +61,20 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
         return $this;
     }
 
+    /**
+     * @param string $proxy
+     * @return RaygunClientFactory
+     */
     public function setProxy(string $proxy): RaygunClientFactory {
         $this->proxy = $proxy;
 
         return $this;
     }
 
+    /**
+     * @param float $timeout
+     * @return RaygunClientFactory
+     */
     public function setTimeout(float $timeout): RaygunClientFactory {
         $this->timeout = $timeout;
 

--- a/src/Raygun4php/Factories/RaygunClientFactory.php
+++ b/src/Raygun4php/Factories/RaygunClientFactory.php
@@ -37,7 +37,8 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
     /**
      * RaygunClientFactory
      *
-     * Builds a RaygunClient object with the HTTP client and transport built with default configurable values to simplify setup
+     * Builds a RaygunClient object with the HTTP client and transport built with default configurable values to
+     * simplify setup
      *
      * @param string $apiKey
      * @param bool $disableUserTracking

--- a/src/Raygun4php/Factories/RaygunClientFactory.php
+++ b/src/Raygun4php/Factories/RaygunClientFactory.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Raygun4php\Factories;
+
+use Psr\Log\LoggerInterface;
+use Raygun4php\Factories\Interfaces\RaygunClientFactoryInterface;
+use Raygun4php\Interfaces\TransportInterface;
+use Raygun4php\RaygunClient;
+
+class RaygunClientFactory implements RaygunClientFactoryInterface
+{
+    /**
+     * @var string
+     */
+    private $apiKey;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var bool
+     */
+    private $useAsync;
+    /**
+     * @var bool
+     */
+    private $disableUserTracking;
+
+    /**
+     * RaygunClientFactory
+     *
+     * Builds a RaygunClient object with the HTTP client and transport built with default configurable values to simplify setup
+     *
+     * @param string $apiKey
+     * @param bool $disableUserTracking
+     * @param bool $useAsync
+     */
+    public function __construct(string $apiKey, bool $disableUserTracking = false, bool $useAsync = true)
+    {
+        $this->apiKey = $apiKey;
+        $this->useAsync = $useAsync;
+        $this->disableUserTracking = $disableUserTracking;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     * @return RaygunClientFactory
+     */
+    public function setLogger(LoggerInterface $logger): RaygunClientFactory
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * @return RaygunClient
+     */
+    public function build(): RaygunClient
+    {
+        $transport = $this->createTransport();
+
+        return new RaygunClient($transport, $this->disableUserTracking);
+    }
+
+    /**
+     * @return TransportInterface
+     */
+    private function createTransport(): TransportInterface
+    {
+        $transportFactory = new TransportFactory($this->apiKey, $this->logger, $this->useAsync);
+        $transport = $transportFactory->build();
+
+        if ($this->useAsync) {
+            register_shutdown_function([$transport, 'wait']);
+        }
+
+        return $transport;
+    }
+}

--- a/src/Raygun4php/Factories/RaygunClientFactory.php
+++ b/src/Raygun4php/Factories/RaygunClientFactory.php
@@ -25,6 +25,8 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
      * @var bool
      */
     private $disableUserTracking;
+    private $proxy;
+    private $timeout;
 
     /**
      * RaygunClientFactory
@@ -53,6 +55,18 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
         return $this;
     }
 
+    public function setProxy(string $proxy): RaygunClientFactory {
+        $this->proxy = $proxy;
+
+        return $this;
+    }
+
+    public function setTimeout(float $timeout): RaygunClientFactory {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
     /**
      * @return RaygunClient
      */
@@ -69,7 +83,7 @@ class RaygunClientFactory implements RaygunClientFactoryInterface
     private function createTransport(): TransportInterface
     {
         $transportFactory = new TransportFactory($this->apiKey, $this->logger, $this->useAsync);
-        $transport = $transportFactory->build();
+        $transport = $transportFactory->build($this->timeout, $this->proxy);
 
         if ($this->useAsync) {
             register_shutdown_function([$transport, 'wait']);

--- a/src/Raygun4php/Factories/TransportFactory.php
+++ b/src/Raygun4php/Factories/TransportFactory.php
@@ -48,10 +48,10 @@ class TransportFactory implements TransportFactoryInterface
     /**
      * @return TransportInterface
      */
-    public function build(): TransportInterface
+    public function build(?float $timeout = null, $proxy = null): TransportInterface
     {
         $httpClientFactory = new HttpClientFactory($this->apiKey);
-        $httpClient = $httpClientFactory->build();
+        $httpClient = $httpClientFactory->build($timeout, $proxy);
 
         $transport = new GuzzleAsync($httpClient);
 

--- a/src/Raygun4php/Factories/TransportFactory.php
+++ b/src/Raygun4php/Factories/TransportFactory.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Raygun4php\Factories;
+
+use GuzzleHttp\ClientInterface;
+use Psr\Log\LoggerInterface;
+use Raygun4php\Factories\Interfaces\TransportFactoryInterface;
+use Raygun4php\Interfaces\TransportInterface;
+use Raygun4php\Transports\GuzzleAsync;
+use Raygun4php\Transports\GuzzleSync;
+
+class TransportFactory implements TransportFactoryInterface
+{
+    /**
+     * @var bool
+     */
+    private $useAsync;
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+    /**
+     * @var string
+     */
+    private $apiKey;
+
+    /**
+     * TransportFactory
+     *
+     * Builds a transport interface with the HTTP client (built with default configurable values) passed in
+     *
+     * @param string $apiKey
+     * @param LoggerInterface|null $logger - PSR-3 compatible logger to attach to the transport for debugging
+     * @param bool $useAsync - Use asynchronous transmission, defaults to true
+     */
+    public function __construct(string $apiKey, LoggerInterface $logger = null, bool $useAsync = true)
+    {
+        $this->apiKey = $apiKey;
+        $this->useAsync = $useAsync;
+        $this->httpClient = new HttpClientFactory($apiKey);
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return TransportInterface
+     */
+    public function build(): TransportInterface
+    {
+        $httpClientFactory = new HttpClientFactory($this->apiKey);
+        $httpClient = $httpClientFactory->build();
+
+        $transport = new GuzzleAsync($httpClient);
+
+        if (!$this->useAsync) {
+            $transport = new GuzzleSync($httpClient);
+        }
+
+        if (!is_null($this->logger)) {
+            $transport->setLogger($this->logger);
+        }
+
+        return $transport;
+    }
+}


### PR DESCRIPTION
## Overview

During testing and documentation, I noticed the RaygunClient setup process was quite verbose and complicated - which could potentially be a barrier. I've created a wrapper class which will take care of building the HTTP client and transport, and just requires an API key (similar to the old API). This also hides the base URI and reduces the number of lines of code required to get set up.