### PR TITLE
Prevent undefined index error on CLI

### DIFF
--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -58,7 +58,7 @@ class RaygunRequestMessage
             }
 
             if (
-                $_SERVER['REQUEST_METHOD'] !== 'GET' &&
+                $this->HttpMethod !== 'GET' &&
                 $contentType != null &&
                 $contentType !== 'application/x-www-form-urlencoded' &&
                 $contentType !== 'multipart/form-data' &&


### PR DESCRIPTION
In some environments, php-cgi is the default binary. In this case, php_sapi_name() reports something like "cgi-fcgi" instead of the expected "cli". When raygun4php captures errors in this environment, it can't detect that PHP is running in a CLI environment and attempts to access some $_SERVER values that don't exist, causing PHP to throw an undefined index error. This patch prevents those errors.