### PR TITLE
Fix deprecation warning trying to covert non-hex string to decimal in PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 cache:
   directories:

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -2,8 +2,8 @@
 
 namespace Raygun4php;
 
-use Raygun4php\Rhumsaa\Uuid\Uuid;
 use Raygun4php\Interfaces\TransportInterface;
+use Raygun4php\Rhumsaa\Uuid\Uuid;
 
 class RaygunClient
 {
@@ -327,7 +327,7 @@ class RaygunClient
         if ($this->is_assoc($userCustomData)) {
             $message->Details->UserCustomData = $userCustomData;
         } else {
-            throw new \Raygun4php\Raygun4PhpException("UserCustomData must be an associative array");
+            throw new Raygun4PhpException("UserCustomData must be an associative array");
         }
     }
 
@@ -358,7 +358,7 @@ class RaygunClient
      * Transmits a RaygunMessage to the Raygun API.
      * This is a lower level function used by SendException and SendError and one of those should be used preferably.
      *
-     * @param \Raygun4php\RaygunMessage $message A populated message to be posted to the Raygun API
+     * @param RaygunMessage $message A populated message to be posted to the Raygun API
      * @return bool Returns true if the transmission attempt is successful.
      *              However, this does not guarantee that the message is delivered.
      */

--- a/src/Raygun4php/RaygunMessage.php
+++ b/src/Raygun4php/RaygunMessage.php
@@ -33,7 +33,12 @@ class RaygunMessage implements RaygunMessageInterface
     private function toJsonRemoveUnicodeSequences($struct)
     {
         return preg_replace_callback("/\\\\u([a-f0-9]{4})/", function ($matches) {
-            return iconv('UCS-4LE', 'UTF-8', pack('V', hexdec("U$matches[1]")));
+            $hex = 'U' . $matches[1];
+            if (!ctype_xdigit($hex)) {
+                // Candidate is not a hexadecimal string, skip
+                return null;
+            }
+            return iconv('UCS-4LE', 'UTF-8', pack('V', hexdec($hex)));
         }, json_encode($struct));
     }
 


### PR DESCRIPTION
Also adds PHP 7.4 to Travis.

Fixes https://github.com/MindscapeHQ/raygun4php/issues/126