### PR TITLE
Simple tweaks for testing to run under php8.0/phpunit 9 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,15 +18,15 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~7.0",
         "psr/log": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "estahn/phpunit-json-assertions": "^3.0"
+        "estahn/phpunit-json-assertions": "^3"
     },
     "suggest": {
         "ext-curl": "*"

--- a/tests/RaygunClientTest.php
+++ b/tests/RaygunClientTest.php
@@ -32,7 +32,7 @@ class RaygunClientTest extends TestCase
      */
     protected $jsonSchema;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->transportMock = $this->getMockBuilder(TransportInterface::class)
                                     ->setMethods(['transmit'])

--- a/tests/RaygunMessageTest.php
+++ b/tests/RaygunMessageTest.php
@@ -18,7 +18,7 @@ class RaygunMessageTest extends TestCase
      */
     protected $jsonSchema;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->jsonSchema = file_get_contents('./tests/misc/RaygunSchema.json');
     }


### PR DESCRIPTION
Hey,

I've just made a few small tweaks here to make it so we can install things under php8.0, and tweaks the testing so it will run under php8.0, there were a few methods that have different signatures in the newer phpunit versions.

Main problem is that the dev-dependancy `estahn/phpunit-json-assertions` is currently pegged at `^7.0` and has not been updated for several years. If the dev-dependancies are installed with php7.4 the tests run and pass when using php8.0

