### PR TITLE
Fixes for phpunit tests on PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 php:
   - '7.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: php
 dist: trusty
 
 php:
-  - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "estahn/phpunit-json-assertions": "^3"
+        "justinrainbow/json-schema": "^5.2"
     },
     "suggest": {
         "ext-curl": "*"

--- a/tests/RaygunClientTest.php
+++ b/tests/RaygunClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Raygun4php\Tests;
 
+use JsonSchema\Validator;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Raygun4php\RaygunClient;
@@ -9,12 +10,9 @@ use Raygun4php\RaygunMessage;
 use Raygun4php\RaygunRequestMessage;
 use Raygun4php\Interfaces\TransportInterface;
 use Raygun4php\Tests\Stubs\TransportGetMessageStub;
-use EnricoStahn\JsonAssert\Assert as JsonAssert;
 
 class RaygunClientTest extends TestCase
 {
-    use JsonAssert;
-
     /**
      * @var RaygunClient
      */
@@ -205,6 +203,10 @@ class RaygunClientTest extends TestCase
         $client->SendException(new \Exception('test'));
         $raygunMessage = $transportStub->getMessage();
 
-        $this->assertJsonMatchesSchemaString($this->jsonSchema, json_decode($raygunMessage->toJson()));
+        $data = json_decode($raygunMessage->toJson());
+
+        $schemaValidator = new Validator();
+        $schemaValidator->validate($data, $this->jsonSchema);
+        $this->assertTrue($schemaValidator->isValid());
     }
 }

--- a/tests/RaygunMessageTest.php
+++ b/tests/RaygunMessageTest.php
@@ -3,14 +3,12 @@
 namespace Raygun4php\Tests;
 
 use Exception;
+use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
 use Raygun4php\RaygunMessage;
-use EnricoStahn\JsonAssert\Assert as JsonAssert;
 
 class RaygunMessageTest extends TestCase
 {
-    use JsonAssert;
-
     /**
      * json schema used to validate message json.
      *
@@ -65,6 +63,10 @@ class RaygunMessageTest extends TestCase
         $msg->build(new Exception('Test'));
 
         $msgJson = $msg->toJson();
-        $this->assertJsonMatchesSchemaString($this->jsonSchema, json_decode($msgJson));
+        $data = json_decode($msgJson);
+
+        $schemaValidator = new Validator();
+        $schemaValidator->validate($data, $this->jsonSchema);
+        $this->assertTrue($schemaValidator->isValid());
     }
 }


### PR DESCRIPTION
- Replace estahn/phpunit-json-assertions with justinrainbow/json-schema for test assertions
- Remove PHP 7.2 and replace with PHP 8.0 in Travis builds

Follow on from https://github.com/MindscapeHQ/raygun4php/pull/132
