### PR TITLE
Fix namespace in Uuid library to prevent bad times

### DIFF
--- a/src/Raygun4php/Rhumsaa/Uuid/Exception/UnsatisfiedDependencyException.php
+++ b/src/Raygun4php/Rhumsaa/Uuid/Exception/UnsatisfiedDependencyException.php
@@ -10,7 +10,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace Raygun4Php\Rhumsaa\Uuid\Exception;
+namespace Raygun4php\Rhumsaa\Uuid\Exception;
 
 /**
  * Thrown to indicate that the requested operation has depencies that have not

--- a/src/Raygun4php/Rhumsaa/Uuid/Exception/UnsupportedOperationException.php
+++ b/src/Raygun4php/Rhumsaa/Uuid/Exception/UnsupportedOperationException.php
@@ -10,7 +10,7 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 
-namespace Raygun4Php\Rhumsaa\Uuid\Exception;
+namespace Raygun4php\Rhumsaa\Uuid\Exception;
 
 /**
  * Thrown to indicate that the requested operation is not supported.

--- a/src/Raygun4php/Rhumsaa/Uuid/Uuid.php
+++ b/src/Raygun4php/Rhumsaa/Uuid/Uuid.php
@@ -11,7 +11,7 @@
  */
 
 /** phpcs:disable */
-namespace Raygun4Php\Rhumsaa\Uuid;
+namespace Raygun4php\Rhumsaa\Uuid;
 
 use InvalidArgumentException;
 


### PR DESCRIPTION
Hey, this is a small PR to correct the namespaces used in the Uuid package to make them consistent with the rest of the package. Newer versions of composer cause errors with mixed case package names as shown in the attached image. 

<img width="1390" alt="Screen Shot 2022-02-01 at 12 52 13 PM" src="https://user-images.githubusercontent.com/1974218/151892182-0c07962b-f63e-48e6-a3c9-4c03bcfdb5f5.png">

