### PR TITLE
Exception line/file of where thrown plus add shortcut to composer for running tests with `composer test

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,39 @@
+name: PHP Composer
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v3
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+    # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+    - name: Run test suite
+      run: composer test

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Composer test on push and pull
 
 on:
   push:

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,8 @@
     },
     "config": {
         "preferred-install": "dist"
+    },
+    "scripts": {
+        "test": ["phpunit"]
     }
 }

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -39,7 +39,7 @@ class RaygunExceptionMessage
         $line = new RaygunExceptionTraceLineMessage();
         $line->FileName = $exceptionOrErrorException->getFile();
         $line->LineNumber = $exceptionOrErrorException->getLine();
-        $lines[] = $line;
+        return $line;
     }
 
     private function BuildErrorTrace($error)

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -39,6 +39,11 @@ class RaygunExceptionMessage
         $traces = $error->getTrace();
         $lines = array();
 
+        $line = new RaygunExceptionTraceLineMessage();
+        $line->FileName = $exception->getFile();
+        $line->LineNumber = $exception->getLine();
+        $lines[] = $line;
+
         foreach ($traces as $trace) {
             $line = new RaygunExceptionTraceLineMessage();
 

--- a/src/Raygun4php/RaygunExceptionMessage.php
+++ b/src/Raygun4php/RaygunExceptionMessage.php
@@ -34,15 +34,20 @@ class RaygunExceptionMessage
         }
     }
 
+    private function getExceptionLine( $exceptionOrErrorException )
+    {
+        $line = new RaygunExceptionTraceLineMessage();
+        $line->FileName = $exceptionOrErrorException->getFile();
+        $line->LineNumber = $exceptionOrErrorException->getLine();
+        $lines[] = $line;
+    }
+
     private function BuildErrorTrace($error)
     {
         $traces = $error->getTrace();
         $lines = array();
 
-        $line = new RaygunExceptionTraceLineMessage();
-        $line->FileName = $exception->getFile();
-        $line->LineNumber = $exception->getLine();
-        $lines[] = $line;
+        $lines[] = $this->getExceptionLine( $error );
 
         foreach ($traces as $trace) {
             $line = new RaygunExceptionTraceLineMessage();
@@ -83,6 +88,8 @@ class RaygunExceptionMessage
     {
         $traces = $exception->getTrace();
         $lines = array();
+
+        $lines[] = $this->getExceptionLine( $exception );
 
         foreach ($traces as $trace) {
             $lines[] = $this->BuildLine($trace);

--- a/tests/RaygunMessageTest.php
+++ b/tests/RaygunMessageTest.php
@@ -47,6 +47,19 @@ class RaygunMessageTest extends TestCase
         $this->assertEquals($msg->Details->Error->Message, 'Exception: test');
     }
 
+    public function testFirstStackTraceLineIsNotNull()
+    {
+        $msg = new RaygunMessage();
+
+        $msg->build(new \Exception('test'));
+        $line = __LINE__ - 1;
+        $file = __FILE__;
+
+        $this->assertNotNull( $msg->Details->Error->StackTrace[0] );
+        $this->assertEquals( $msg->Details->Error->StackTrace[0]->LineNumber, $line );
+        $this->assertEquals( $msg->Details->Error->StackTrace[0]->FileName, $file );
+    }
+
     public function testBuildMessageWithNestedException()
     {
         $msg = new RaygunMessage();


### PR DESCRIPTION
easier unit test running. instead of vendor/bin/phpunit
add more complete exception payload to message

Fixes #147 