### PR TITLE
Fix invalid characters deprecation (v1.x)

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -435,7 +435,7 @@ namespace Raygun4php {
     }
 
     function toJsonRemoveUnicodeSequences($struct) {
-      return preg_replace_callback("/\\\\u([a-f0-9]{4})/", function($matches){ return iconv('UCS-4LE','UTF-8',pack('V', hexdec("U$matches[1]"))); }, json_encode($struct));
+      return preg_replace_callback("/\\\\u([a-f0-9]{4})/", function($matches){ return iconv('UCS-4LE','UTF-8',pack('V', hexdec($matches[1]))); }, json_encode($struct));
     }
 
     function removeNullBytes($string) {


### PR DESCRIPTION
Converting hexadecimal characters causes a deprecation in PHP 7.4+.

The problem was addressed in the 2.x line in #126. This is a fix for 1.x.

The issue was that hexdec() was being passed a non-hexadecimal character: "U". Previous versions of PHP silently ignored it, then in 7.4 supplying non-hexadecimal characters was deprecated and no longer silent.

This change removes the "U".