### PR TITLE
Improve setUser functionality

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -193,7 +193,7 @@ class RaygunClient
         $isAnonymousCookie = $this->StoreOrRetrieveUserCookie('rgisanonymous', $isAnonymous ? 'true' : 'false');
         $this->isAnonymous = ($isAnonymousCookie === 'true');
 
-        if (isset($user) && !$isAnonymous) {
+        if ((is_string($user) || is_numeric($user)) && !$isAnonymous) {
             $this->user = $user;
             $this->firstName = $this->StoreOrRetrieveUserCookie('rgfirstname', $firstName);
             $this->fullName = $this->StoreOrRetrieveUserCookie('rgfullname', $fullName);

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -190,16 +190,15 @@ class RaygunClient
         $isAnonymous = null,
         $uuid = null
     ) {
-        $this->firstName = $this->StoreOrRetrieveUserCookie('rgfirstname', $firstName);
-        $this->fullName = $this->StoreOrRetrieveUserCookie('rgfullname', $fullName);
-        $this->email = $this->StoreOrRetrieveUserCookie('rgemail', $email);
-
-        $this->uuid = $this->StoreOrRetrieveUserCookie('rguuidvalue', $uuid);
         $isAnonymousCookie = $this->StoreOrRetrieveUserCookie('rgisanonymous', $isAnonymous ? 'true' : 'false');
         $this->isAnonymous = ($isAnonymousCookie === 'true');
 
-        if (is_string($user)) {
+        if (isset($user) && !$isAnonymous) {
             $this->user = $user;
+            $this->firstName = $this->StoreOrRetrieveUserCookie('rgfirstname', $firstName);
+            $this->fullName = $this->StoreOrRetrieveUserCookie('rgfullname', $fullName);
+            $this->email = $this->StoreOrRetrieveUserCookie('rgemail', $email);
+            $this->uuid = $this->StoreOrRetrieveUserCookie('rguuidvalue', $uuid);
 
             if (php_sapi_name() != 'cli' && !headers_sent()) {
                 $this->setCookie('rguserid', $user);

--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -190,15 +190,16 @@ class RaygunClient
         $isAnonymous = null,
         $uuid = null
     ) {
+        $this->firstName = $this->StoreOrRetrieveUserCookie('rgfirstname', $firstName);
+        $this->fullName = $this->StoreOrRetrieveUserCookie('rgfullname', $fullName);
+        $this->email = $this->StoreOrRetrieveUserCookie('rgemail', $email);
+        $this->uuid = $this->StoreOrRetrieveUserCookie('rguuidvalue', $uuid);
+
         $isAnonymousCookie = $this->StoreOrRetrieveUserCookie('rgisanonymous', $isAnonymous ? 'true' : 'false');
         $this->isAnonymous = ($isAnonymousCookie === 'true');
 
         if ((is_string($user) || is_numeric($user)) && !$isAnonymous) {
             $this->user = $user;
-            $this->firstName = $this->StoreOrRetrieveUserCookie('rgfirstname', $firstName);
-            $this->fullName = $this->StoreOrRetrieveUserCookie('rgfullname', $fullName);
-            $this->email = $this->StoreOrRetrieveUserCookie('rgemail', $email);
-            $this->uuid = $this->StoreOrRetrieveUserCookie('rguuidvalue', $uuid);
 
             if (php_sapi_name() != 'cli' && !headers_sent()) {
                 $this->setCookie('rguserid', $user);


### PR DESCRIPTION
This PR makes some improvements to the `SetUser` method. We've had a couple users confused as to why their users aren't being set properly and this is likely due to it not being clear in our documentation that `setUser` expects the `user` parametre to be a string, otherwise the user will be set to anonymous. I've updated the provider to accept numbers for this parametre now. 

**Changes:**
-  The `user` parameter now expects both strings and number data types – the `is_string` and `is_numeric` checks just make sure we're not getting any unexpected data types