### PR TITLE
Support newer versions of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "justinrainbow/json-schema": "^5.2",
-        "colinodell/psr-testlogger": "^1.1"
+        "justinrainbow/json-schema": "^5.2"
     },
     "suggest": {
         "ext-curl": "*"

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,13 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~7.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.0",
-        "justinrainbow/json-schema": "^5.2"
+        "justinrainbow/json-schema": "^5.2",
+        "colinodell/psr-testlogger": "^1.1"
     },
     "suggest": {
         "ext-curl": "*"

--- a/tests/Transports/GuzzleAsyncTest.php
+++ b/tests/Transports/GuzzleAsyncTest.php
@@ -2,6 +2,7 @@
 
 namespace Raygun4php\Tests\Transports;
 
+use ColinODell\PsrTestLogger\TestLogger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
@@ -9,7 +10,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\Test\TestLogger;
 use Raygun4php\RaygunMessage;
 use Raygun4php\Transports\GuzzleAsync;
 

--- a/tests/Transports/GuzzleAsyncTest.php
+++ b/tests/Transports/GuzzleAsyncTest.php
@@ -2,7 +2,6 @@
 
 namespace Raygun4php\Tests\Transports;
 
-use ColinODell\PsrTestLogger\TestLogger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Handler\MockHandler;
@@ -10,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Raygun4php\RaygunMessage;
 use Raygun4php\Transports\GuzzleAsync;
 
@@ -28,13 +28,12 @@ class GuzzleAsyncTest extends TestCase
         $transport = new GuzzleAsync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('error');
         $transport->setLogger($logger);
 
         $transport->transmit($message);
         $transport->wait();
-
-        $this->assertTrue($logger->hasErrorRecords());
     }
 
     public function testTransmitLogsWarningIfResponseCodeIs200()
@@ -49,13 +48,12 @@ class GuzzleAsyncTest extends TestCase
         $transport = new GuzzleAsync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('warning');
         $transport->setLogger($logger);
 
         $transport->transmit($message);
         $transport->wait();
-
-        $this->assertTrue($logger->hasWarningRecords());
     }
 
     public function testTransmitLogsErrorIfHttpClientThrowsException()
@@ -71,12 +69,11 @@ class GuzzleAsyncTest extends TestCase
 
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('error');
         $transport->setLogger($logger);
 
         $transport->transmit($message);
         $transport->wait();
-
-        $this->assertTrue($logger->hasErrorRecords());
     }
 }

--- a/tests/Transports/GuzzleSyncTest.php
+++ b/tests/Transports/GuzzleSyncTest.php
@@ -2,10 +2,10 @@
 
 namespace Raygun4php\Tests\Transports;
 
-use ColinODell\PsrTestLogger\TestLogger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
@@ -72,12 +72,11 @@ class GuzzleSyncTest extends TestCase
         $transport = new GuzzleSync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())->method('error');
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-
-        $this->assertTrue($logger->hasErrorRecords());
     }
 
     public function testTransmitLogsRelevant400Message()
@@ -92,12 +91,13 @@ class GuzzleSyncTest extends TestCase
         $transport = new GuzzleSync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+               ->method('error')
+               ->with($this->stringContains('400'));
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-
-        $this->assertTrue($logger->hasErrorThatContains('400'));
     }
 
     public function testTransmitLogsRelevant400MessageNoException()
@@ -115,12 +115,13 @@ class GuzzleSyncTest extends TestCase
         $transport = new GuzzleSync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+               ->method('error')
+               ->with($this->stringContains('400'));
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-
-        $this->assertTrue($logger->hasErrorThatContains('400'));
     }
 
     public function testTransmitLogsRelevant403Message()
@@ -135,12 +136,13 @@ class GuzzleSyncTest extends TestCase
         $transport = new GuzzleSync($client);
         $message = new RaygunMessage();
 
-        $logger = new TestLogger();
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->atLeastOnce())
+               ->method('error')
+               ->with($this->stringContains('403'));
         $transport->setLogger($logger);
 
         $transport->transmit($message);
-
-        $this->assertTrue($logger->hasErrorThatContains('403'));
     }
 
     public function testTransmitReturnsFalseOnHttpStatus400NoException()

--- a/tests/Transports/GuzzleSyncTest.php
+++ b/tests/Transports/GuzzleSyncTest.php
@@ -2,6 +2,7 @@
 
 namespace Raygun4php\Tests\Transports;
 
+use ColinODell\PsrTestLogger\TestLogger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use PHPUnit\Framework\TestCase;
@@ -9,7 +10,6 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use Psr\Log\Test\TestLogger;
 use Raygun4php\RaygunMessage;
 use Raygun4php\Transports\GuzzleSync;
 


### PR DESCRIPTION
psr/log 2.0 removes the `TestLogger` class, so I've replaced its usage with PHPUnit mocks.