### PR TITLE
Remove usage of deprecated utf8_encode function

### DIFF
--- a/src/Raygun4php/RaygunRequestMessage.php
+++ b/src/Raygun4php/RaygunRequestMessage.php
@@ -42,7 +42,7 @@ class RaygunRequestMessage
         $utf8_convert_server = function ($value) use (&$utf8_convert_server) {
             return is_array($value) ?
             array_map($utf8_convert_server, $value) :
-            iconv('UTF-8', 'UTF-8', utf8_encode($value));
+            iconv('ISO-8859-1', 'UTF-8', $value);
         };
 
         $this->Form = array_map($utf8_convert, $_POST);

--- a/tests/RaygunClientTest.php
+++ b/tests/RaygunClientTest.php
@@ -277,4 +277,19 @@ class RaygunClientTest extends TestCase
         $schemaValidator->validate($data, $this->jsonSchema);
         $this->assertTrue($schemaValidator->isValid());
     }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testServerUtf8Conversion()
+    {
+        $_SERVER = [
+            'a' => 'hello',
+            'b' => "\xc0\xde",
+        ];
+        $requestMessage = new RaygunRequestMessage();
+
+        $this->assertSame('hello', $requestMessage->Data['a']);
+        $this->assertSame('ÀÞ', $requestMessage->Data['b']);
+    }
 }


### PR DESCRIPTION
`utf8_encode` is [deprecated in PHP 8.2](https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated). Fortunately, we're already making use of iconv, and it's straightforward enough to use `iconv` to convert from ISO-8859-1 instead of `utf8_encode`.

I have to admit I'm not entirely clear on the purpose of this conversion. It appears to have been added quite a while ago in a08a28ab7b03bc7a86789f065983777a651b72c2, and may not be relevant anymore in newer PHP versions? Hard for me to say.