### PR TITLE
Don't save a null value with setcookie()

### DIFF
--- a/src/Raygun4php/RaygunClient.php
+++ b/src/Raygun4php/RaygunClient.php
@@ -243,14 +243,14 @@ class RaygunClient
     {
         if (is_string($value)) {
             if (php_sapi_name() != 'cli' && !headers_sent()) {
-                $this->setCookie($key, $value);
+                $this->setCookie($key, $value ?? '');
             }
 
             return $value;
         } else {
             if (array_key_exists($key, $_COOKIE)) {
                 if ($_COOKIE[$key] != $value && php_sapi_name() != 'cli' && !headers_sent()) {
-                    $this->setCookie($key, $value);
+                    $this->setCookie($key, $value ?? '');
                 }
                 return $_COOKIE[$key];
             }


### PR DESCRIPTION
Because of some php api changes, we should not be passing a null value to the setcookie() method. (e.g. fullName)

This PR fixes that.