### PR TITLE
Update README to include PHP 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Raygun4PHP
 ==========
 
-[Raygun.com](http://raygun.com) provider for PHP 7.2+
+[Raygun.com](http://raygun.com) provider for PHP 7.2/8+
 
 _See [v1.8 documentation](https://github.com/MindscapeHQ/raygun4php/blob/1.8/README.md) for PHP v5.3+ support_
 


### PR DESCRIPTION
The readme says PHP 7.2+ but we already support 8+ too, so just mentioning it explicitly.